### PR TITLE
Extend appointment fields

### DIFF
--- a/src/components/TurnoForm.jsx
+++ b/src/components/TurnoForm.jsx
@@ -4,23 +4,50 @@ import { collection, addDoc } from 'firebase/firestore';
 
 export default function TurnoForm() {
   const [nombre, setNombre] = useState('');
+  const [fecha, setFecha] = useState('');
+  const [servicio, setServicio] = useState('');
+  const [barbero, setBarbero] = useState('');
 
   const guardarTurno = async () => {
-    if (!nombre) return;
+    if (!nombre || !fecha || !servicio || !barbero) return;
     await addDoc(collection(db, 'turnos'), {
       nombre,
-      timestamp: new Date()
+      fecha,
+      servicio,
+      barbero,
+      timestamp: new Date(),
     });
     setNombre('');
+    setFecha('');
+    setServicio('');
+    setBarbero('');
   };
 
   return (
-    <div className="flex items-center space-x-2 mb-4">
+    <div className="flex flex-col space-y-2 mb-4">
       <input
-        className="border p-2 rounded flex-grow"
+        className="border p-2 rounded"
         value={nombre}
         onChange={(e) => setNombre(e.target.value)}
         placeholder="Nombre del cliente"
+      />
+      <input
+        type="date"
+        className="border p-2 rounded"
+        value={fecha}
+        onChange={(e) => setFecha(e.target.value)}
+      />
+      <input
+        className="border p-2 rounded"
+        value={servicio}
+        onChange={(e) => setServicio(e.target.value)}
+        placeholder="Servicio"
+      />
+      <input
+        className="border p-2 rounded"
+        value={barbero}
+        onChange={(e) => setBarbero(e.target.value)}
+        placeholder="Nombre del barbero"
       />
       <button
         onClick={guardarTurno}

--- a/src/components/TurnoForm.jsx
+++ b/src/components/TurnoForm.jsx
@@ -5,20 +5,23 @@ import { collection, addDoc } from 'firebase/firestore';
 export default function TurnoForm() {
   const [nombre, setNombre] = useState('');
   const [fecha, setFecha] = useState('');
+  const [hora, setHora] = useState('');
   const [servicio, setServicio] = useState('');
   const [barbero, setBarbero] = useState('');
 
   const guardarTurno = async () => {
-    if (!nombre || !fecha || !servicio || !barbero) return;
+    if (!nombre || !fecha || !hora || !servicio || !barbero) return;
     await addDoc(collection(db, 'turnos'), {
       nombre,
       fecha,
+      hora,
       servicio,
       barbero,
       timestamp: new Date(),
     });
     setNombre('');
     setFecha('');
+    setHora('');
     setServicio('');
     setBarbero('');
   };
@@ -36,6 +39,12 @@ export default function TurnoForm() {
         className="border p-2 rounded"
         value={fecha}
         onChange={(e) => setFecha(e.target.value)}
+      />
+      <input
+        type="time"
+        className="border p-2 rounded"
+        value={hora}
+        onChange={(e) => setHora(e.target.value)}
       />
       <input
         className="border p-2 rounded"

--- a/src/components/TurnosList.jsx
+++ b/src/components/TurnosList.jsx
@@ -30,6 +30,7 @@ export default function TurnosList() {
             </button>
           </div>
           <p className="text-sm text-gray-700">Fecha: {turno.fecha}</p>
+          <p className="text-sm text-gray-700">Hora: {turno.hora}</p>
           <p className="text-sm text-gray-700">Servicio: {turno.servicio}</p>
           <p className="text-sm text-gray-700">Barbero: {turno.barbero}</p>
         </li>

--- a/src/components/TurnosList.jsx
+++ b/src/components/TurnosList.jsx
@@ -19,14 +19,19 @@ export default function TurnosList() {
   return (
     <ul className="space-y-2">
       {turnos.map((turno) => (
-        <li key={turno.id} className="flex items-center justify-between p-2 border rounded">
-          <span>{turno.nombre}</span>
-          <button
-            onClick={() => eliminarTurno(turno.id)}
-            className="text-red-600 hover:underline"
-          >
-            Eliminar
-          </button>
+        <li key={turno.id} className="p-2 border rounded">
+          <div className="flex justify-between">
+            <span className="font-semibold">{turno.nombre}</span>
+            <button
+              onClick={() => eliminarTurno(turno.id)}
+              className="text-red-600 hover:underline"
+            >
+              Eliminar
+            </button>
+          </div>
+          <p className="text-sm text-gray-700">Fecha: {turno.fecha}</p>
+          <p className="text-sm text-gray-700">Servicio: {turno.servicio}</p>
+          <p className="text-sm text-gray-700">Barbero: {turno.barbero}</p>
         </li>
       ))}
     </ul>


### PR DESCRIPTION
## Summary
- include date, service and barber name in appointment form
- display the new fields in the appointments list

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68467795899c8328821c667732ca4099