### PR TITLE
Add service management page and dropdown

### DIFF
--- a/src/components/ServiceForm.jsx
+++ b/src/components/ServiceForm.jsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import { db } from '../auth/FirebaseConfig';
+import { collection, addDoc } from 'firebase/firestore';
+
+export default function ServiceForm() {
+  const [nombre, setNombre] = useState('');
+
+  const guardarServicio = async () => {
+    if (!nombre) return;
+    await addDoc(collection(db, 'servicios'), {
+      nombre,
+      timestamp: new Date(),
+    });
+    setNombre('');
+  };
+
+  return (
+    <div className="flex flex-col space-y-2 mb-4">
+      <input
+        className="border p-2 rounded"
+        value={nombre}
+        onChange={(e) => setNombre(e.target.value)}
+        placeholder="Nombre del servicio"
+      />
+      <button
+        onClick={guardarServicio}
+        className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
+      >
+        Guardar servicio
+      </button>
+    </div>
+  );
+}

--- a/src/components/ServiceList.jsx
+++ b/src/components/ServiceList.jsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import { db } from '../auth/FirebaseConfig';
+import { collection, onSnapshot, deleteDoc, doc } from 'firebase/firestore';
+
+export default function ServiceList() {
+  const [servicios, setServicios] = useState([]);
+
+  useEffect(() => {
+    const unsubscribe = onSnapshot(collection(db, 'servicios'), (snapshot) => {
+      setServicios(snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() })));
+    });
+    return () => unsubscribe();
+  }, []);
+
+  const eliminarServicio = async (id) => {
+    await deleteDoc(doc(db, 'servicios', id));
+  };
+
+  return (
+    <ul className="space-y-2">
+      {servicios.map((servicio) => (
+        <li key={servicio.id} className="p-2 border rounded flex justify-between">
+          <span>{servicio.nombre}</span>
+          <button
+            onClick={() => eliminarServicio(servicio.id)}
+            className="text-red-600 hover:underline"
+          >
+            Eliminar
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/TurnoForm.jsx
+++ b/src/components/TurnoForm.jsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { db } from '../auth/FirebaseConfig';
-import { collection, addDoc } from 'firebase/firestore';
+import { collection, addDoc, onSnapshot } from 'firebase/firestore';
 
 export default function TurnoForm() {
   const [nombre, setNombre] = useState('');
@@ -8,6 +8,14 @@ export default function TurnoForm() {
   const [hora, setHora] = useState('');
   const [servicio, setServicio] = useState('');
   const [barbero, setBarbero] = useState('');
+  const [servicios, setServicios] = useState([]);
+
+  useEffect(() => {
+    const unsubscribe = onSnapshot(collection(db, 'servicios'), (snapshot) => {
+      setServicios(snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() })));
+    });
+    return () => unsubscribe();
+  }, []);
 
   const guardarTurno = async () => {
     if (!nombre || !fecha || !hora || !servicio || !barbero) return;
@@ -46,12 +54,18 @@ export default function TurnoForm() {
         value={hora}
         onChange={(e) => setHora(e.target.value)}
       />
-      <input
+      <select
         className="border p-2 rounded"
         value={servicio}
         onChange={(e) => setServicio(e.target.value)}
-        placeholder="Servicio"
-      />
+      >
+        <option value="">Seleccione un servicio</option>
+        {servicios.map((s) => (
+          <option key={s.id} value={s.nombre}>
+            {s.nombre}
+          </option>
+        ))}
+      </select>
       <input
         className="border p-2 rounded"
         value={barbero}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -5,6 +5,12 @@ export default function Dashboard() {
   return (
     <div className="p-4">
       <h2 className="text-xl font-semibold mb-4">Dashboard de Turnos</h2>
+      <a
+        href="#/servicios"
+        className="text-blue-600 hover:underline block mb-4"
+      >
+        Gestionar servicios
+      </a>
       <TurnoForm />
       <TurnosList />
     </div>

--- a/src/pages/Services.jsx
+++ b/src/pages/Services.jsx
@@ -1,0 +1,12 @@
+import ServiceForm from '../components/ServiceForm';
+import ServiceList from '../components/ServiceList';
+
+export default function Services() {
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-semibold mb-4">Gestionar Servicios</h2>
+      <ServiceForm />
+      <ServiceList />
+    </div>
+  );
+}

--- a/src/router/AppRouter.jsx
+++ b/src/router/AppRouter.jsx
@@ -1,6 +1,7 @@
 import { HashRouter, Routes, Route } from 'react-router-dom';
 import Home from '../pages/Home';
 import Dashboard from '../pages/Dashboard';
+import Services from '../pages/Services';
 
 export default function AppRouter() {
   return (
@@ -8,6 +9,7 @@ export default function AppRouter() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/dashboard" element={<Dashboard />} />
+        <Route path="/servicios" element={<Services />} />
       </Routes>
     </HashRouter>
   );


### PR DESCRIPTION
## Summary
- add page and components to manage service types
- fetch service types when creating appointments
- link to service management from dashboard
- expose service page in router

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68467cd58be88328b7355ba36e732702