### PR TITLE
Integrate DaisyUI for turnos

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "gh-pages": "^5.0.0",
     "vite": "^5.0.0",
     "@vitejs/plugin-react": "^4.0.0",
+    "daisyui": "^4.11.0",
     "tailwindcss": "^3.4.4",
     "postcss": "^8.4.38",
     "autoprefixer": "^10.4.16"

--- a/src/components/TurnosList.jsx
+++ b/src/components/TurnosList.jsx
@@ -17,24 +17,26 @@ export default function TurnosList() {
   };
 
   return (
-    <ul className="space-y-2">
+    <div className="grid gap-4">
       {turnos.map((turno) => (
-        <li key={turno.id} className="p-2 border rounded">
-          <div className="flex justify-between">
-            <span className="font-semibold">{turno.nombre}</span>
-            <button
-              onClick={() => eliminarTurno(turno.id)}
-              className="text-red-600 hover:underline"
-            >
-              Eliminar
-            </button>
+        <div key={turno.id} className="card bg-base-100 shadow-md">
+          <div className="card-body">
+            <div className="flex justify-between items-start">
+              <h2 className="card-title">{turno.nombre}</h2>
+              <button
+                onClick={() => eliminarTurno(turno.id)}
+                className="btn btn-sm btn-error"
+              >
+                Eliminar
+              </button>
+            </div>
+            <p>Fecha: {turno.fecha}</p>
+            <p>Hora: {turno.hora}</p>
+            <p>Servicio: {turno.servicio}</p>
+            <p>Barbero: {turno.barbero}</p>
           </div>
-          <p className="text-sm text-gray-700">Fecha: {turno.fecha}</p>
-          <p className="text-sm text-gray-700">Hora: {turno.hora}</p>
-          <p className="text-sm text-gray-700">Servicio: {turno.servicio}</p>
-          <p className="text-sm text-gray-700">Barbero: {turno.barbero}</p>
-        </li>
+        </div>
       ))}
-    </ul>
+    </div>
   );
 }

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -3,7 +3,7 @@ import TurnosList from '../components/TurnosList';
 
 export default function Dashboard() {
   return (
-    <div className="p-4">
+    <div className="container mx-auto p-4">
       <h2 className="text-xl font-semibold mb-4">Dashboard de Turnos</h2>
       <a
         href="#/servicios"
@@ -11,8 +11,10 @@ export default function Dashboard() {
       >
         Gestionar servicios
       </a>
-      <TurnoForm />
-      <TurnosList />
+      <div className="grid gap-6 md:grid-cols-2">
+        <TurnoForm />
+        <TurnosList />
+      </div>
     </div>
   );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,10 +1,12 @@
+import daisyui from 'daisyui';
+
 export default {
   content: [
     './index.html',
-    './src/**/*.{js,jsx}'
+    './src/**/*.{js,jsx}',
   ],
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: [daisyui],
 };


### PR DESCRIPTION
## Summary
- add DaisyUI plugin to Tailwind config
- display each pending appointment using DaisyUI card component
- include DaisyUI as a development dependency

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68477999bda48328b0519acebe2f9df0