### PR TITLE
Add barber management page and dropdown

### DIFF
--- a/src/components/BarberForm.jsx
+++ b/src/components/BarberForm.jsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import { db } from '../auth/FirebaseConfig';
+import { collection, addDoc } from 'firebase/firestore';
+
+export default function BarberForm() {
+  const [nombre, setNombre] = useState('');
+
+  const guardarBarbero = async () => {
+    if (!nombre) return;
+    await addDoc(collection(db, 'barberos'), {
+      nombre,
+      timestamp: new Date(),
+    });
+    setNombre('');
+  };
+
+  return (
+    <div className="flex flex-col space-y-2 mb-4">
+      <input
+        className="border p-2 rounded"
+        value={nombre}
+        onChange={(e) => setNombre(e.target.value)}
+        placeholder="Nombre del barbero"
+      />
+      <button
+        onClick={guardarBarbero}
+        className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
+      >
+        Guardar barbero
+      </button>
+    </div>
+  );
+}

--- a/src/components/BarberList.jsx
+++ b/src/components/BarberList.jsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import { db } from '../auth/FirebaseConfig';
+import { collection, onSnapshot, deleteDoc, doc } from 'firebase/firestore';
+
+export default function BarberList() {
+  const [barberos, setBarberos] = useState([]);
+
+  useEffect(() => {
+    const unsubscribe = onSnapshot(collection(db, 'barberos'), (snapshot) => {
+      setBarberos(snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() })));
+    });
+    return () => unsubscribe();
+  }, []);
+
+  const eliminarBarbero = async (id) => {
+    await deleteDoc(doc(db, 'barberos', id));
+  };
+
+  return (
+    <ul className="space-y-2">
+      {barberos.map((barbero) => (
+        <li key={barbero.id} className="p-2 border rounded flex justify-between">
+          <span>{barbero.nombre}</span>
+          <button
+            onClick={() => eliminarBarbero(barbero.id)}
+            className="text-red-600 hover:underline"
+          >
+            Eliminar
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/TurnoForm.jsx
+++ b/src/components/TurnoForm.jsx
@@ -9,12 +9,19 @@ export default function TurnoForm() {
   const [servicio, setServicio] = useState('');
   const [barbero, setBarbero] = useState('');
   const [servicios, setServicios] = useState([]);
+  const [barberos, setBarberos] = useState([]);
 
   useEffect(() => {
-    const unsubscribe = onSnapshot(collection(db, 'servicios'), (snapshot) => {
+    const unsubServicios = onSnapshot(collection(db, 'servicios'), (snapshot) => {
       setServicios(snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() })));
     });
-    return () => unsubscribe();
+    const unsubBarberos = onSnapshot(collection(db, 'barberos'), (snapshot) => {
+      setBarberos(snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() })));
+    });
+    return () => {
+      unsubServicios();
+      unsubBarberos();
+    };
   }, []);
 
   const guardarTurno = async () => {
@@ -66,12 +73,18 @@ export default function TurnoForm() {
           </option>
         ))}
       </select>
-      <input
+      <select
         className="border p-2 rounded"
         value={barbero}
         onChange={(e) => setBarbero(e.target.value)}
-        placeholder="Nombre del barbero"
-      />
+      >
+        <option value="">Seleccione un barbero</option>
+        {barberos.map((b) => (
+          <option key={b.id} value={b.nombre}>
+            {b.nombre}
+          </option>
+        ))}
+      </select>
       <button
         onClick={guardarTurno}
         className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"

--- a/src/pages/Barbers.jsx
+++ b/src/pages/Barbers.jsx
@@ -1,0 +1,12 @@
+import BarberForm from '../components/BarberForm';
+import BarberList from '../components/BarberList';
+
+export default function Barbers() {
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-semibold mb-4">Gestionar Barberos</h2>
+      <BarberForm />
+      <BarberList />
+    </div>
+  );
+}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -11,6 +11,12 @@ export default function Dashboard() {
       >
         Gestionar servicios
       </a>
+      <a
+        href="#/barberos"
+        className="text-blue-600 hover:underline block mb-4"
+      >
+        Gestionar barberos
+      </a>
       <div className="grid gap-6 md:grid-cols-2">
         <TurnoForm />
         <TurnosList />

--- a/src/router/AppRouter.jsx
+++ b/src/router/AppRouter.jsx
@@ -2,6 +2,7 @@ import { HashRouter, Routes, Route } from 'react-router-dom';
 import Home from '../pages/Home';
 import Dashboard from '../pages/Dashboard';
 import Services from '../pages/Services';
+import Barbers from '../pages/Barbers';
 
 export default function AppRouter() {
   return (
@@ -10,6 +11,7 @@ export default function AppRouter() {
         <Route path="/" element={<Home />} />
         <Route path="/dashboard" element={<Dashboard />} />
         <Route path="/servicios" element={<Services />} />
+        <Route path="/barberos" element={<Barbers />} />
       </Routes>
     </HashRouter>
   );


### PR DESCRIPTION
## Summary
- add barber form and list components for CRUD
- create Barbers page and link from dashboard
- load barbers from Firestore in TurnoForm as select
- update router with `/barberos` route

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68477cf37200832884e3a31ea5560ad2