### PR TITLE
Limit dashboard to barber's appointments

### DIFF
--- a/src/components/AllTurnosList.jsx
+++ b/src/components/AllTurnosList.jsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import { db } from '../auth/FirebaseConfig';
+import { collection, onSnapshot, deleteDoc, doc, query, orderBy } from 'firebase/firestore';
+
+export default function AllTurnosList() {
+  const [turnos, setTurnos] = useState([]);
+
+  useEffect(() => {
+    const q = query(collection(db, 'turnos'), orderBy('timestamp', 'desc'));
+    const unsubscribe = onSnapshot(q, snapshot => {
+      setTurnos(snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() })));
+    });
+    return () => unsubscribe();
+  }, []);
+
+  const eliminarTurno = async id => {
+    await deleteDoc(doc(db, 'turnos', id));
+  };
+
+  return (
+    <div className="grid gap-4">
+      {turnos.map(turno => (
+        <div key={turno.id} className="card bg-base-100 shadow-md">
+          <div className="card-body">
+            <div className="flex justify-between items-start">
+              <h2 className="card-title">{turno.nombre}</h2>
+              <button onClick={() => eliminarTurno(turno.id)} className="btn btn-sm btn-error">
+                Eliminar
+              </button>
+            </div>
+            <p>Fecha: {turno.fecha}</p>
+            <p>Hora: {turno.hora}</p>
+            <p>Servicio: {turno.servicio}</p>
+            <p>Barbero: {turno.barbero}</p>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -3,6 +3,8 @@ import { auth } from '../auth/FirebaseConfig';
 import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 
+const ADMIN_EMAILS = ['admin@example.com'];
+
 export default function LoginForm() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -12,7 +14,10 @@ export default function LoginForm() {
     e.preventDefault();
     try {
       await signInWithEmailAndPassword(auth, email, password);
-      navigate('/dashboard');
+      const destination = ADMIN_EMAILS.includes(email.toLowerCase())
+        ? '/admin'
+        : '/dashboard';
+      navigate(destination);
     } catch (error) {
       alert('Error de autenticación');
     }

--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -3,7 +3,7 @@ import { auth } from '../auth/FirebaseConfig';
 import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 
-const ADMIN_EMAILS = ['admin@example.com'];
+const ADMIN_EMAILS = ['super@hotmail.com'];
 
 export default function LoginForm() {
   const [email, setEmail] = useState('');

--- a/src/components/TurnoForm.jsx
+++ b/src/components/TurnoForm.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { db } from '../auth/FirebaseConfig';
+import { auth, db } from '../auth/FirebaseConfig';
 import { collection, addDoc, onSnapshot } from 'firebase/firestore';
 
 export default function TurnoForm() {
@@ -26,12 +26,14 @@ export default function TurnoForm() {
 
   const guardarTurno = async () => {
     if (!nombre || !fecha || !hora || !servicio || !barbero) return;
+    const userId = auth.currentUser ? auth.currentUser.uid : null;
     await addDoc(collection(db, 'turnos'), {
       nombre,
       fecha,
       hora,
       servicio,
       barbero,
+      userId,
       timestamp: new Date(),
     });
     setNombre('');

--- a/src/pages/AdminDashboard.jsx
+++ b/src/pages/AdminDashboard.jsx
@@ -5,6 +5,18 @@ export default function AdminDashboard() {
   return (
     <div className="container mx-auto p-4">
       <h2 className="text-xl font-semibold mb-4">Super Admin - Turnos</h2>
+      <a
+        href="#/servicios"
+        className="text-blue-600 hover:underline block mb-4"
+      >
+        Gestionar servicios
+      </a>
+      <a
+        href="#/barberos"
+        className="text-blue-600 hover:underline block mb-4"
+      >
+        Gestionar barberos
+      </a>
       <div className="grid gap-6 md:grid-cols-2">
         <TurnoForm />
         <AllTurnosList />

--- a/src/pages/AdminDashboard.jsx
+++ b/src/pages/AdminDashboard.jsx
@@ -1,0 +1,14 @@
+import TurnoForm from '../components/TurnoForm';
+import AllTurnosList from '../components/AllTurnosList';
+
+export default function AdminDashboard() {
+  return (
+    <div className="container mx-auto p-4">
+      <h2 className="text-xl font-semibold mb-4">Super Admin - Turnos</h2>
+      <div className="grid gap-6 md:grid-cols-2">
+        <TurnoForm />
+        <AllTurnosList />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -5,20 +5,7 @@ export default function Dashboard() {
   return (
     <div className="container mx-auto p-4">
       <h2 className="text-xl font-semibold mb-4">Dashboard de Turnos</h2>
-      <a
-        href="#/servicios"
-        className="text-blue-600 hover:underline block mb-4"
-      >
-        Gestionar servicios
-      </a>
-      <a
-        href="#/barberos"
-        className="text-blue-600 hover:underline block mb-4"
-      >
-        Gestionar barberos
-      </a>
       <div className="grid gap-6 md:grid-cols-2">
-        <TurnoForm />
         <TurnosList />
       </div>
     </div>

--- a/src/router/AppRouter.jsx
+++ b/src/router/AppRouter.jsx
@@ -3,6 +3,7 @@ import Home from '../pages/Home';
 import Dashboard from '../pages/Dashboard';
 import Services from '../pages/Services';
 import Barbers from '../pages/Barbers';
+import AdminDashboard from '../pages/AdminDashboard';
 
 export default function AppRouter() {
   return (
@@ -12,6 +13,7 @@ export default function AppRouter() {
         <Route path="/dashboard" element={<Dashboard />} />
         <Route path="/servicios" element={<Services />} />
         <Route path="/barberos" element={<Barbers />} />
+        <Route path="/admin" element={<AdminDashboard />} />
       </Routes>
     </HashRouter>
   );


### PR DESCRIPTION
## Summary
- save the current user's uid when creating appointments
- filter appointments in `TurnosList` so each barber sees only their own

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684788e160908328acf2cd2581a1646b