### PR TITLE
Add barber schedule management

### DIFF
--- a/src/components/BarberHorarioForm.jsx
+++ b/src/components/BarberHorarioForm.jsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react';
+import { auth, db } from '../auth/FirebaseConfig';
+import { collection, addDoc, onSnapshot, query, where } from 'firebase/firestore';
+import { onAuthStateChanged } from 'firebase/auth';
+
+export default function BarberHorarioForm() {
+  const [fecha, setFecha] = useState('');
+  const [hora, setHora] = useState('');
+  const [barbero, setBarbero] = useState('');
+
+  useEffect(() => {
+    let unsubBarbero;
+    const unsubAuth = onAuthStateChanged(auth, (user) => {
+      if (user) {
+        const qBarbero = query(collection(db, 'barberos'), where('email', '==', user.email));
+        unsubBarbero = onSnapshot(qBarbero, (snap) => {
+          if (!snap.empty) {
+            setBarbero(snap.docs[0].data().nombre);
+          } else {
+            setBarbero('');
+          }
+        });
+      } else {
+        setBarbero('');
+      }
+    });
+    return () => {
+      if (unsubBarbero) unsubBarbero();
+      unsubAuth();
+    };
+  }, []);
+
+  const guardarHorario = async () => {
+    if (!fecha || !hora || !barbero) return;
+    await addDoc(collection(db, 'horarios'), {
+      barbero,
+      fecha,
+      hora,
+      timestamp: new Date(),
+    });
+    setFecha('');
+    setHora('');
+  };
+
+  return (
+    <div className="flex flex-col space-y-2 mb-4">
+      <input
+        type="date"
+        className="border p-2 rounded"
+        value={fecha}
+        onChange={(e) => setFecha(e.target.value)}
+      />
+      <input
+        type="time"
+        className="border p-2 rounded"
+        value={hora}
+        onChange={(e) => setHora(e.target.value)}
+      />
+      <button
+        onClick={guardarHorario}
+        className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
+      >
+        Guardar horario
+      </button>
+    </div>
+  );
+}

--- a/src/components/BarberHorarioList.jsx
+++ b/src/components/BarberHorarioList.jsx
@@ -1,0 +1,114 @@
+import { useEffect, useState } from 'react';
+import { auth, db } from '../auth/FirebaseConfig';
+import {
+  collection,
+  onSnapshot,
+  query,
+  where,
+  doc,
+  updateDoc,
+  deleteDoc,
+} from 'firebase/firestore';
+import { onAuthStateChanged } from 'firebase/auth';
+
+export default function BarberHorarioList() {
+  const [horarios, setHorarios] = useState([]);
+  const [editingId, setEditingId] = useState(null);
+  const [editFecha, setEditFecha] = useState('');
+  const [editHora, setEditHora] = useState('');
+
+  useEffect(() => {
+    let unsubHorarios;
+    let unsubBarbero;
+    const unsubAuth = onAuthStateChanged(auth, (user) => {
+      if (user) {
+        const qBarbero = query(collection(db, 'barberos'), where('email', '==', user.email));
+        unsubBarbero = onSnapshot(qBarbero, (snap) => {
+          if (!snap.empty) {
+            const nombre = snap.docs[0].data().nombre;
+            const qHorarios = query(collection(db, 'horarios'), where('barbero', '==', nombre));
+            unsubHorarios = onSnapshot(qHorarios, (s) => {
+              setHorarios(s.docs.map((d) => ({ id: d.id, ...d.data() })));
+            });
+          } else {
+            setHorarios([]);
+          }
+        });
+      } else {
+        setHorarios([]);
+      }
+    });
+    return () => {
+      if (unsubHorarios) unsubHorarios();
+      if (unsubBarbero) unsubBarbero();
+      unsubAuth();
+    };
+  }, []);
+
+  const startEdit = (h) => {
+    setEditingId(h.id);
+    setEditFecha(h.fecha);
+    setEditHora(h.hora);
+  };
+
+  const guardarEdicion = async (id) => {
+    if (!editFecha || !editHora) return;
+    await updateDoc(doc(db, 'horarios', id), {
+      fecha: editFecha,
+      hora: editHora,
+    });
+    setEditingId(null);
+  };
+
+  const eliminarHorario = async (id) => {
+    await deleteDoc(doc(db, 'horarios', id));
+  };
+
+  return (
+    <div className="grid gap-4">
+      {horarios.map((h) => (
+        <div key={h.id} className="card bg-base-100 shadow-md p-4">
+          {editingId === h.id ? (
+            <div className="space-y-2">
+              <input
+                type="date"
+                className="border p-2 rounded"
+                value={editFecha}
+                onChange={(e) => setEditFecha(e.target.value)}
+              />
+              <input
+                type="time"
+                className="border p-2 rounded"
+                value={editHora}
+                onChange={(e) => setEditHora(e.target.value)}
+              />
+              <div className="space-x-2">
+                <button onClick={() => guardarEdicion(h.id)} className="btn btn-primary btn-sm">
+                  Guardar
+                </button>
+                <button onClick={() => setEditingId(null)} className="btn btn-secondary btn-sm">
+                  Cancelar
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="flex justify-between items-start">
+              <div>
+                <p className="font-semibold">{h.fecha}</p>
+                <p>{h.hora}</p>
+              </div>
+              <div className="space-x-2">
+                <button onClick={() => startEdit(h)} className="btn btn-sm">
+                  Editar
+                </button>
+                <button onClick={() => eliminarHorario(h.id)} className="btn btn-error btn-sm">
+                  Eliminar
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/pages/BarberDashboard.jsx
+++ b/src/pages/BarberDashboard.jsx
@@ -1,10 +1,15 @@
 import BarberMisTurnos from '../components/BarberMisTurnos';
+import BarberHorarioForm from '../components/BarberHorarioForm';
+import BarberHorarioList from '../components/BarberHorarioList';
 
 export default function BarberDashboard() {
   return (
     <div className="container mx-auto p-4">
       <h2 className="text-xl font-semibold mb-4">Mis turnos asignados</h2>
       <BarberMisTurnos />
+      <h2 className="text-xl font-semibold my-4">Mis horarios de trabajo</h2>
+      <BarberHorarioForm />
+      <BarberHorarioList />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add form and list to manage barber work schedules
- expose schedule management from dashboard

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ae45c9014832883d45244607c2c3c