### PR TITLE
Implement availability-based scheduling

### DIFF
--- a/src/components/BarberScheduleForm.jsx
+++ b/src/components/BarberScheduleForm.jsx
@@ -1,0 +1,58 @@
+import { useState, useEffect } from 'react';
+import { auth, db } from '../auth/FirebaseConfig';
+import { collection, addDoc, onSnapshot, query, where } from 'firebase/firestore';
+import { onAuthStateChanged } from 'firebase/auth';
+
+export default function BarberScheduleForm() {
+  const [barbero, setBarbero] = useState('');
+  const [servicio, setServicio] = useState('');
+  const [fecha, setFecha] = useState('');
+  const [hora, setHora] = useState('');
+  const [servicios, setServicios] = useState([]);
+
+  useEffect(() => {
+    const unsubServicios = onSnapshot(collection(db, 'servicios'), snap => {
+      setServicios(snap.docs.map(doc => ({ id: doc.id, ...doc.data() })));
+    });
+    const unsubAuth = onAuthStateChanged(auth, user => {
+      if (user) {
+        const q = query(collection(db, 'barberos'), where('email', '==', user.email));
+        onSnapshot(q, snap => {
+          if (!snap.empty) setBarbero(snap.docs[0].data().nombre);
+        });
+      }
+    });
+    return () => {
+      unsubServicios();
+      unsubAuth();
+    };
+  }, []);
+
+  const guardar = async () => {
+    if (!barbero || !servicio || !fecha || !hora) return;
+    await addDoc(collection(db, 'disponibilidades'), {
+      barbero,
+      servicio,
+      fecha,
+      hora,
+      timestamp: new Date(),
+    });
+    setServicio('');
+    setFecha('');
+    setHora('');
+  };
+
+  return (
+    <div className="flex flex-col space-y-2 mb-4">
+      <select className="border p-2 rounded" value={servicio} onChange={e => setServicio(e.target.value)}>
+        <option value="">Seleccione un servicio</option>
+        {servicios.map(s => (
+          <option key={s.id} value={s.nombre}>{s.nombre}</option>
+        ))}
+      </select>
+      <input type="date" className="border p-2 rounded" value={fecha} onChange={e => setFecha(e.target.value)} />
+      <input type="time" className="border p-2 rounded" value={hora} onChange={e => setHora(e.target.value)} />
+      <button onClick={guardar} className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">Agregar horario</button>
+    </div>
+  );
+}

--- a/src/components/TurnoForm.jsx
+++ b/src/components/TurnoForm.jsx
@@ -1,28 +1,58 @@
 import { useState, useEffect } from 'react';
 import { auth, db } from '../auth/FirebaseConfig';
-import { collection, addDoc, onSnapshot } from 'firebase/firestore';
+import { collection, addDoc, onSnapshot, query, where } from 'firebase/firestore';
 
 export default function TurnoForm() {
-  const [nombre, setNombre] = useState('');
+  const [servicio, setServicio] = useState('');
   const [fecha, setFecha] = useState('');
   const [hora, setHora] = useState('');
-  const [servicio, setServicio] = useState('');
+  const [nombre, setNombre] = useState('');
   const [barbero, setBarbero] = useState('');
   const [servicios, setServicios] = useState([]);
-  const [barberos, setBarberos] = useState([]);
+  const [horasDisponibles, setHorasDisponibles] = useState([]);
+  const [barberosDisponibles, setBarberosDisponibles] = useState([]);
 
   useEffect(() => {
-    const unsubServicios = onSnapshot(collection(db, 'servicios'), (snapshot) => {
-      setServicios(snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() })));
+    const unsubServicios = onSnapshot(collection(db, 'servicios'), snap => {
+      setServicios(snap.docs.map(doc => ({ id: doc.id, ...doc.data() })));
     });
-    const unsubBarberos = onSnapshot(collection(db, 'barberos'), (snapshot) => {
-      setBarberos(snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() })));
-    });
-    return () => {
-      unsubServicios();
-      unsubBarberos();
-    };
+    return () => unsubServicios();
   }, []);
+
+  useEffect(() => {
+    if (servicio && fecha) {
+      const q = query(
+        collection(db, 'disponibilidades'),
+        where('servicio', '==', servicio),
+        where('fecha', '==', fecha)
+      );
+      const unsub = onSnapshot(q, snap => {
+        const horas = [...new Set(snap.docs.map(d => d.data().hora))];
+        setHorasDisponibles(horas);
+      });
+      return () => unsub();
+    } else {
+      setHorasDisponibles([]);
+    }
+  }, [servicio, fecha]);
+
+  useEffect(() => {
+    if (servicio && fecha && hora) {
+      const q = query(
+        collection(db, 'disponibilidades'),
+        where('servicio', '==', servicio),
+        where('fecha', '==', fecha),
+        where('hora', '==', hora)
+      );
+      const unsub = onSnapshot(q, snap => {
+        const barbs = [...new Set(snap.docs.map(d => d.data().barbero))];
+        setBarberosDisponibles(barbs);
+      });
+      return () => unsub();
+    } else {
+      setBarberosDisponibles([]);
+    }
+  }, [servicio, fecha, hora]);
 
   const guardarTurno = async () => {
     if (!nombre || !fecha || !hora || !servicio || !barbero) return;
@@ -45,54 +75,39 @@ export default function TurnoForm() {
 
   return (
     <div className="flex flex-col space-y-2 mb-4">
-      <input
-        className="border p-2 rounded"
-        value={nombre}
-        onChange={(e) => setNombre(e.target.value)}
-        placeholder="Nombre del cliente"
-      />
-      <input
-        type="date"
-        className="border p-2 rounded"
-        value={fecha}
-        onChange={(e) => setFecha(e.target.value)}
-      />
-      <input
-        type="time"
-        className="border p-2 rounded"
-        value={hora}
-        onChange={(e) => setHora(e.target.value)}
-      />
-      <select
-        className="border p-2 rounded"
-        value={servicio}
-        onChange={(e) => setServicio(e.target.value)}
-      >
+      <select className="border p-2 rounded" value={servicio} onChange={e => setServicio(e.target.value)}>
         <option value="">Seleccione un servicio</option>
-        {servicios.map((s) => (
-          <option key={s.id} value={s.nombre}>
-            {s.nombre}
-          </option>
+        {servicios.map(s => (
+          <option key={s.id} value={s.nombre}>{s.nombre}</option>
         ))}
       </select>
-      <select
-        className="border p-2 rounded"
-        value={barbero}
-        onChange={(e) => setBarbero(e.target.value)}
-      >
-        <option value="">Seleccione un barbero</option>
-        {barberos.map((b) => (
-          <option key={b.id} value={b.nombre}>
-            {b.nombre}
-          </option>
-        ))}
-      </select>
-      <button
-        onClick={guardarTurno}
-        className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
-      >
-        Guardar turno
-      </button>
+      {servicio && (
+        <input type="date" className="border p-2 rounded" value={fecha} onChange={e => setFecha(e.target.value)} />
+      )}
+      {horasDisponibles.length > 0 && (
+        <select className="border p-2 rounded" value={hora} onChange={e => setHora(e.target.value)}>
+          <option value="">Seleccione una hora</option>
+          {horasDisponibles.map(h => (
+            <option key={h} value={h}>{h}</option>
+          ))}
+        </select>
+      )}
+      {barberosDisponibles.length > 0 && (
+        <select className="border p-2 rounded" value={barbero} onChange={e => setBarbero(e.target.value)}>
+          <option value="">Seleccione un barbero</option>
+          {barberosDisponibles.map(b => (
+            <option key={b} value={b}>{b}</option>
+          ))}
+        </select>
+      )}
+      {barbero && (
+        <input className="border p-2 rounded" value={nombre} onChange={e => setNombre(e.target.value)} placeholder="Nombre del cliente" />
+      )}
+      {barbero && (
+        <button onClick={guardarTurno} className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700">
+          Guardar turno
+        </button>
+      )}
     </div>
   );
 }

--- a/src/pages/BarberDashboard.jsx
+++ b/src/pages/BarberDashboard.jsx
@@ -1,9 +1,12 @@
 import BarberMisTurnos from '../components/BarberMisTurnos';
+import BarberScheduleForm from '../components/BarberScheduleForm';
 
 export default function BarberDashboard() {
   return (
     <div className="container mx-auto p-4">
-      <h2 className="text-xl font-semibold mb-4">Mis turnos asignados</h2>
+      <h2 className="text-xl font-semibold mb-4">Cargar horarios disponibles</h2>
+      <BarberScheduleForm />
+      <h2 className="text-xl font-semibold mb-4 mt-8">Mis turnos asignados</h2>
       <BarberMisTurnos />
     </div>
   );


### PR DESCRIPTION
## Summary
- add `BarberScheduleForm` for barbers to register available time slots
- adjust `TurnoForm` so clients first pick service and date
- filter available hours and barbers based on registered availability
- show schedule form on `BarberDashboard`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ae830fddc832886e4d13c546091b5