### PR TITLE
Add Firestore seeding helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,15 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Seeding Firestore
+
+1. Create a Firebase service account and download the JSON credential.
+2. Save the file as `service-account.json` in the project root or set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable with the path to the file.
+3. Run the seeding script:
+
+```bash
+node scripts/seedFirestore.js
+```
+
+This will populate example records for barbers, services, availability slots and appointments.

--- a/scripts/seedFirestore.js
+++ b/scripts/seedFirestore.js
@@ -1,0 +1,53 @@
+const admin = require('firebase-admin');
+
+const serviceAccountPath = process.env.GOOGLE_APPLICATION_CREDENTIALS || './service-account.json';
+const serviceAccount = require(serviceAccountPath);
+
+admin.initializeApp({
+  credential: admin.credential.cert(serviceAccount),
+});
+
+const db = admin.firestore();
+
+const barbers = [
+  { nombre: 'Juan', email: 'juan@example.com' },
+  { nombre: 'Maria', email: 'maria@example.com' },
+];
+
+const services = [
+  { nombre: 'Corte de pelo', precio: 10 },
+  { nombre: 'Afeitado', precio: 5 },
+];
+
+const slots = [
+  { barbero: 'Juan', servicio: 'Corte de pelo', fecha: '2024-01-01', hora: '10:00' },
+  { barbero: 'Maria', servicio: 'Afeitado', fecha: '2024-01-01', hora: '11:00' },
+];
+
+const appointments = [
+  { nombre: 'Pedro', servicio: 'Corte de pelo', fecha: '2024-01-01', hora: '10:00', barbero: 'Juan' },
+];
+
+async function seedCollection(name, data) {
+  await Promise.all(
+    data.map((item) =>
+      db.collection(name).add({ ...item, timestamp: new Date(), userId: item.userId || null })
+    )
+  );
+}
+
+async function main() {
+  try {
+    await seedCollection('barberos', barbers);
+    await seedCollection('servicios', services);
+    await seedCollection('disponibilidades', slots);
+    await seedCollection('turnos', appointments);
+    console.log('Seeding completed');
+  } catch (err) {
+    console.error(err);
+  } finally {
+    process.exit();
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add `scripts/seedFirestore.js` for seeding Firestore collections
- document how to run the script in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686419e140d48328ac57698a4defca8f