### PR TITLE
Group barber schedules by day with tabs

### DIFF
--- a/src/components/BarberMisTurnos.jsx
+++ b/src/components/BarberMisTurnos.jsx
@@ -1,10 +1,38 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo, useRef } from 'react';
 import { auth, db } from '../auth/FirebaseConfig';
 import { collection, onSnapshot, query, where } from 'firebase/firestore';
 import { onAuthStateChanged } from 'firebase/auth';
 
 export default function BarberMisTurnos() {
   const [turnos, setTurnos] = useState([]);
+  const [activeDate, setActiveDate] = useState('');
+  const tabsRef = useRef(null);
+
+  const scrollLeft = () => {
+    if (tabsRef.current) {
+      tabsRef.current.scrollBy({ left: -150, behavior: 'smooth' });
+    }
+  };
+
+  const scrollRight = () => {
+    if (tabsRef.current) {
+      tabsRef.current.scrollBy({ left: 150, behavior: 'smooth' });
+    }
+  };
+
+  const dates = useMemo(() => {
+    const today = new Date().toISOString().split('T')[0];
+    const unique = Array.from(new Set(turnos.map(t => t.fecha)));
+    return unique
+      .filter(d => d >= today)
+      .sort();
+  }, [turnos]);
+
+  useEffect(() => {
+    if (dates.length > 0 && !dates.includes(activeDate)) {
+      setActiveDate(dates[0]);
+    }
+  }, [dates, activeDate]);
 
   useEffect(() => {
     let unsubTurnos;
@@ -40,16 +68,49 @@ export default function BarberMisTurnos() {
     };
   }, []);
 
+  if (turnos.length === 0) {
+    return <p>No tienes turnos asignados.</p>;
+  }
+
   return (
-    <div className="grid gap-4">
-      {turnos.map((t) => (
-        <div key={t.id} className="card bg-base-100 shadow-md p-4">
-          <p className="font-semibold">{t.nombre}</p>
-          <p>
-            {t.fecha} {t.hora} - {t.servicio}
-          </p>
+    <div className="space-y-4">
+      <div className="flex items-center">
+        <button onClick={scrollLeft} className="btn btn-square btn-sm mr-2">
+          ❮
+        </button>
+        <div
+          ref={tabsRef}
+          role="tablist"
+          className="tabs tabs-bordered flex-1 overflow-x-auto whitespace-nowrap scroll-smooth"
+        >
+          {dates.map(date => (
+            <button
+              key={date}
+              role="tab"
+              className={`tab ${activeDate === date ? 'tab-active' : ''}`}
+              onClick={() => setActiveDate(date)}
+            >
+              {date}
+            </button>
+          ))}
         </div>
-      ))}
+        <button onClick={scrollRight} className="btn btn-square btn-sm ml-2">
+          ❯
+        </button>
+      </div>
+
+      <div className="grid gap-4">
+        {turnos
+          .filter(t => t.fecha === activeDate)
+          .map(t => (
+            <div key={t.id} className="card bg-base-100 shadow-md p-4">
+              <p className="font-semibold">{t.nombre}</p>
+              <p>
+                {t.fecha} {t.hora} - {t.servicio}
+              </p>
+            </div>
+          ))}
+      </div>
     </div>
   );
 }

--- a/src/components/BarberScheduleList.jsx
+++ b/src/components/BarberScheduleList.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useState, useMemo, useRef } from 'react';
 import { auth, db } from '../auth/FirebaseConfig';
 import { collection, onSnapshot, query, where, deleteDoc, doc } from 'firebase/firestore';
 import { onAuthStateChanged } from 'firebase/auth';
@@ -7,10 +7,26 @@ export default function BarberScheduleList() {
   const [slots, setSlots] = useState([]);
   const [bookings, setBookings] = useState([]);
   const [activeDate, setActiveDate] = useState('');
+  const tabsRef = useRef(null);
+
+  const scrollLeft = () => {
+    if (tabsRef.current) {
+      tabsRef.current.scrollBy({ left: -150, behavior: 'smooth' });
+    }
+  };
+
+  const scrollRight = () => {
+    if (tabsRef.current) {
+      tabsRef.current.scrollBy({ left: 150, behavior: 'smooth' });
+    }
+  };
 
   const dates = useMemo(() => {
+    const today = new Date().toISOString().split('T')[0];
     const unique = Array.from(new Set(slots.map(s => s.fecha)));
-    return unique.sort();
+    return unique
+      .filter(d => d >= today)
+      .sort();
   }, [slots]);
 
   useEffect(() => {
@@ -63,17 +79,29 @@ export default function BarberScheduleList() {
 
   return (
     <div className="space-y-4">
-      <div role="tablist" className="tabs tabs-bordered">
-        {dates.map(date => (
-          <button
-            key={date}
-            role="tab"
-            className={`tab ${activeDate === date ? 'tab-active' : ''}`}
-            onClick={() => setActiveDate(date)}
-          >
-            {date}
-          </button>
-        ))}
+      <div className="flex items-center">
+        <button onClick={scrollLeft} className="btn btn-square btn-sm mr-2">
+          ❮
+        </button>
+        <div
+          ref={tabsRef}
+          role="tablist"
+          className="tabs tabs-bordered flex-1 overflow-x-auto whitespace-nowrap scroll-smooth"
+        >
+          {dates.map(date => (
+            <button
+              key={date}
+              role="tab"
+              className={`tab ${activeDate === date ? 'tab-active' : ''}`}
+              onClick={() => setActiveDate(date)}
+            >
+              {date}
+            </button>
+          ))}
+        </div>
+        <button onClick={scrollRight} className="btn btn-square btn-sm ml-2">
+          ❯
+        </button>
       </div>
 
       <div className="grid gap-4">

--- a/src/pages/BarberDashboard.jsx
+++ b/src/pages/BarberDashboard.jsx
@@ -1,9 +1,12 @@
+import { useState } from 'react';
 import BarberMisTurnos from '../components/BarberMisTurnos';
 import BarberScheduleForm from '../components/BarberScheduleForm';
 import BarberScheduleList from '../components/BarberScheduleList';
 import UserMenu from '../components/UserMenu';
 
 export default function BarberDashboard() {
+  const [section, setSection] = useState('cargar');
+
   return (
     <div className="p-4 space-y-6">
       <div className="flex justify-between items-center">
@@ -11,28 +14,59 @@ export default function BarberDashboard() {
         <UserMenu />
       </div>
 
-      <div className="grid gap-6 md:grid-cols-2">
+      <ul className="menu menu-horizontal bg-base-200 rounded-box">
+        <li>
+          <a
+            onClick={() => setSection('cargar')}
+            className={section === 'cargar' ? 'active' : ''}
+          >
+            Cargar horario
+          </a>
+        </li>
+        <li>
+          <a
+            onClick={() => setSection('cargados')}
+            className={section === 'cargados' ? 'active' : ''}
+          >
+            Horarios cargados
+          </a>
+        </li>
+        <li>
+          <a
+            onClick={() => setSection('turnos')}
+            className={section === 'turnos' ? 'active' : ''}
+          >
+            Turnos asignados
+          </a>
+        </li>
+      </ul>
+
+      {section === 'cargar' && (
         <div className="card bg-base-100 shadow">
           <div className="card-body">
             <h3 className="card-title">Cargar horarios disponibles</h3>
             <BarberScheduleForm />
           </div>
         </div>
+      )}
 
+      {section === 'cargados' && (
         <div className="card bg-base-100 shadow">
           <div className="card-body">
             <h3 className="card-title">Horarios cargados</h3>
             <BarberScheduleList />
           </div>
         </div>
+      )}
 
-        <div className="card bg-base-100 shadow md:col-span-2">
+      {section === 'turnos' && (
+        <div className="card bg-base-100 shadow">
           <div className="card-body">
             <h3 className="card-title">Mis turnos asignados</h3>
             <BarberMisTurnos />
           </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- enhance `BarberScheduleList` with DaisyUI tabs
- show a tab for each scheduled day and list day-specific slots

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68641fca4ce483289ce460eea1353876