### PR TITLE
Add phone fields and WhatsApp notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,18 @@ node scripts/seedFirestore.js
 ```
 
 This will populate example records for barbers, services, availability slots and appointments.
+
+## Cloud Functions
+
+The `functions` folder contains a Cloud Function that sends WhatsApp notifications
+when a new appointment is created. Configure your Twilio credentials using
+
+```
+firebase functions:config:set twilio.sid="ACCOUNT_SID" twilio.token="AUTH_TOKEN" twilio.number="whatsapp:+123456789"
+```
+
+Then deploy with:
+
+```
+firebase deploy --only functions
+```

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,5 @@
+{
+  "functions": {
+    "source": "functions"
+  }
+}

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,0 +1,50 @@
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+const twilio = require('twilio');
+
+admin.initializeApp();
+
+const accountSid = functions.config().twilio.sid;
+const authToken = functions.config().twilio.token;
+const fromNumber = functions.config().twilio.number;
+const client = twilio(accountSid, authToken);
+
+exports.onTurnoCreate = functions.firestore
+  .document('turnos/{turnoId}')
+  .onCreate(async (snap) => {
+    const turno = snap.data();
+    const barberSnap = await admin
+      .firestore()
+      .collection('barberos')
+      .where('nombre', '==', turno.barbero)
+      .limit(1)
+      .get();
+
+    if (barberSnap.empty) {
+      return null;
+    }
+    const barber = barberSnap.docs[0].data();
+
+    const messages = [];
+    if (turno.telefono) {
+      messages.push(
+        client.messages.create({
+          from: `whatsapp:${fromNumber}`,
+          to: `whatsapp:${turno.telefono}`,
+          body: `Hola ${turno.nombre}, tu turno para ${turno.servicio} el ${turno.fecha} a las ${turno.hora} con ${turno.barbero} ha sido registrado.`,
+        })
+      );
+    }
+
+    if (barber.telefono) {
+      messages.push(
+        client.messages.create({
+          from: `whatsapp:${fromNumber}`,
+          to: `whatsapp:${barber.telefono}`,
+          body: `Nuevo turno para ${turno.nombre} el ${turno.fecha} a las ${turno.hora} para ${turno.servicio}.`,
+        })
+      );
+    }
+
+    return Promise.all(messages);
+  });

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "functions",
+  "engines": {"node": "18"},
+  "main": "index.js",
+  "dependencies": {
+    "firebase-admin": "^12.0.0",
+    "firebase-functions": "^4.0.0",
+    "twilio": "^4.0.0"
+  }
+}

--- a/scripts/seedFirestore.js
+++ b/scripts/seedFirestore.js
@@ -10,8 +10,8 @@ admin.initializeApp({
 const db = admin.firestore();
 
 const barbers = [
-  { nombre: 'Juan', email: 'juan@example.com' },
-  { nombre: 'Maria', email: 'maria@example.com' },
+  { nombre: 'Juan', email: 'juan@example.com', telefono: '+573000000001' },
+  { nombre: 'Maria', email: 'maria@example.com', telefono: '+573000000002' },
 ];
 
 const services = [
@@ -25,7 +25,7 @@ const slots = [
 ];
 
 const appointments = [
-  { nombre: 'Pedro', servicio: 'Corte de pelo', fecha: '2024-01-01', hora: '10:00', barbero: 'Juan' },
+  { nombre: 'Pedro', email: 'pedro@example.com', telefono: '+573000000003', servicio: 'Corte de pelo', fecha: '2024-01-01', hora: '10:00', barbero: 'Juan' },
 ];
 
 async function seedCollection(name, data) {

--- a/src/components/AllTurnosList.jsx
+++ b/src/components/AllTurnosList.jsx
@@ -33,6 +33,8 @@ export default function AllTurnosList() {
             <p>Hora: {formatHoraBogota(turno.hora)}</p>
             <p>Servicio: {turno.servicio}</p>
             <p>Barbero: {turno.barbero}</p>
+            {turno.email && <p>Email: {turno.email}</p>}
+            {turno.telefono && <p>Teléfono: {turno.telefono}</p>}
           </div>
         </div>
       ))}

--- a/src/components/BarberForm.jsx
+++ b/src/components/BarberForm.jsx
@@ -7,10 +7,11 @@ import { getAuth, createUserWithEmailAndPassword } from 'firebase/auth';
 export default function BarberForm() {
   const [nombre, setNombre] = useState('');
   const [email, setEmail] = useState('');
+  const [telefono, setTelefono] = useState('');
   const [password, setPassword] = useState('');
 
   const guardarBarbero = async () => {
-    if (!nombre || !email || !password) return;
+    if (!nombre || !email || !telefono || !password) return;
 
     // crear usuario sin afectar la sesión actual
     const auxApp = initializeApp(firebaseConfig, 'aux');
@@ -20,11 +21,13 @@ export default function BarberForm() {
     await addDoc(collection(db, 'barberos'), {
       nombre,
       email,
+      telefono,
       timestamp: new Date(),
     });
 
     setNombre('');
     setEmail('');
+    setTelefono('');
     setPassword('');
   };
 
@@ -42,6 +45,12 @@ export default function BarberForm() {
         value={email}
         onChange={(e) => setEmail(e.target.value)}
         placeholder="Correo electrónico"
+      />
+      <input
+        className="border p-2 rounded"
+        value={telefono}
+        onChange={(e) => setTelefono(e.target.value)}
+        placeholder="Teléfono"
       />
       <input
         className="border p-2 rounded"

--- a/src/components/BarberList.jsx
+++ b/src/components/BarberList.jsx
@@ -23,6 +23,7 @@ export default function BarberList() {
           <span>
             {barbero.nombre}
             {barbero.email ? ` - ${barbero.email}` : ''}
+            {barbero.telefono ? ` - ${barbero.telefono}` : ''}
           </span>
           <button
             onClick={() => eliminarBarbero(barbero.id)}

--- a/src/components/BarberMisTurnos.jsx
+++ b/src/components/BarberMisTurnos.jsx
@@ -173,6 +173,8 @@ export default function BarberMisTurnos() {
               <p>
                 {t.fecha} {formatHoraBogota(t.hora)} - {t.servicio}
               </p>
+              {t.email && <p>Email: {t.email}</p>}
+              {t.telefono && <p>Tel\u00e9fono: {t.telefono}</p>}
               <div className="space-x-2">
                 <button
                   disabled={(t.estado || 'pendiente') !== 'pendiente'}

--- a/src/components/TurnoForm.jsx
+++ b/src/components/TurnoForm.jsx
@@ -14,6 +14,8 @@ export default function TurnoForm() {
   const [fecha, setFecha] = useState('');
   const [hora, setHora] = useState('');
   const [nombre, setNombre] = useState('');
+  const [email, setEmail] = useState('');
+  const [telefono, setTelefono] = useState('');
   const [barbero, setBarbero] = useState('');
   const [servicios, setServicios] = useState([]);
   const [horasDisponibles, setHorasDisponibles] = useState([]);
@@ -114,10 +116,12 @@ export default function TurnoForm() {
   }, [servicio, fecha, hora, barberosOcupados]);
 
   const guardarTurno = async () => {
-    if (!nombre || !fecha || !hora || !servicio || !barbero) return;
+    if (!nombre || !email || !telefono || !fecha || !hora || !servicio || !barbero) return;
     const userId = auth.currentUser ? auth.currentUser.uid : null;
     await addDoc(collection(db, 'turnos'), {
       nombre,
+      email,
+      telefono,
       fecha,
       hora,
       servicio,
@@ -129,6 +133,8 @@ export default function TurnoForm() {
     setExito(true);
     setTimeout(() => setExito(false), 3000);
     setNombre('');
+    setEmail('');
+    setTelefono('');
     setFecha('');
     setHora('');
     setServicio('');
@@ -170,6 +176,12 @@ export default function TurnoForm() {
       )}
       {barbero && (
         <input className="border p-2 rounded" value={nombre} onChange={e => setNombre(e.target.value)} placeholder="Nombre del cliente" />
+      )}
+      {barbero && (
+        <input className="border p-2 rounded" type="email" value={email} onChange={e => setEmail(e.target.value)} placeholder="Correo del cliente" />
+      )}
+      {barbero && (
+        <input className="border p-2 rounded" value={telefono} onChange={e => setTelefono(e.target.value)} placeholder="Tel\u00e9fono del cliente" />
       )}
       {barbero && (
         <button onClick={guardarTurno} className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700">

--- a/src/components/TurnosList.jsx
+++ b/src/components/TurnosList.jsx
@@ -56,6 +56,8 @@ export default function TurnosList() {
             <p>Hora: {formatHoraBogota(turno.hora)}</p>
             <p>Servicio: {turno.servicio}</p>
             <p>Barbero: {turno.barbero}</p>
+            {turno.email && <p>Email: {turno.email}</p>}
+            {turno.telefono && <p>Teléfono: {turno.telefono}</p>}
           </div>
         </div>
       ))}

--- a/src/pages/BarberProfile.jsx
+++ b/src/pages/BarberProfile.jsx
@@ -30,6 +30,7 @@ export default function BarberProfile() {
       </div>
       <h1 className="text-3xl font-bold">{barbero.nombre}</h1>
       {barbero.email && <p className="text-lg">{barbero.email}</p>}
+      {barbero.telefono && <p className="text-lg">Tel: {barbero.telefono}</p>}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- capture email and phone when scheduling a turn
- support phone field for barbers
- show phone/email in lists
- seed firestore with phone and email
- add Firebase Cloud Function to notify via WhatsApp

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68644695db188328898345907c9c900a