### PR TITLE
Add phone and email fields

### DIFF
--- a/scripts/seedFirestore.js
+++ b/scripts/seedFirestore.js
@@ -10,8 +10,8 @@ admin.initializeApp({
 const db = admin.firestore();
 
 const barbers = [
-  { nombre: 'Juan', email: 'juan@example.com' },
-  { nombre: 'Maria', email: 'maria@example.com' },
+  { nombre: 'Juan', email: 'juan@example.com', telefono: '111-111' },
+  { nombre: 'Maria', email: 'maria@example.com', telefono: '222-222' },
 ];
 
 const services = [
@@ -25,7 +25,15 @@ const slots = [
 ];
 
 const appointments = [
-  { nombre: 'Pedro', servicio: 'Corte de pelo', fecha: '2024-01-01', hora: '10:00', barbero: 'Juan' },
+  {
+    nombre: 'Pedro',
+    servicio: 'Corte de pelo',
+    fecha: '2024-01-01',
+    hora: '10:00',
+    barbero: 'Juan',
+    email: 'pedro@example.com',
+    telefono: '333-333',
+  },
 ];
 
 async function seedCollection(name, data) {

--- a/src/components/AllTurnosList.jsx
+++ b/src/components/AllTurnosList.jsx
@@ -33,6 +33,8 @@ export default function AllTurnosList() {
             <p>Hora: {formatHoraBogota(turno.hora)}</p>
             <p>Servicio: {turno.servicio}</p>
             <p>Barbero: {turno.barbero}</p>
+            {turno.email && <p>Correo: {turno.email}</p>}
+            {turno.telefono && <p>Teléfono: {turno.telefono}</p>}
           </div>
         </div>
       ))}

--- a/src/components/BarberForm.jsx
+++ b/src/components/BarberForm.jsx
@@ -7,10 +7,11 @@ import { getAuth, createUserWithEmailAndPassword } from 'firebase/auth';
 export default function BarberForm() {
   const [nombre, setNombre] = useState('');
   const [email, setEmail] = useState('');
+  const [telefono, setTelefono] = useState('');
   const [password, setPassword] = useState('');
 
   const guardarBarbero = async () => {
-    if (!nombre || !email || !password) return;
+    if (!nombre || !email || !telefono || !password) return;
 
     // crear usuario sin afectar la sesión actual
     const auxApp = initializeApp(firebaseConfig, 'aux');
@@ -20,11 +21,13 @@ export default function BarberForm() {
     await addDoc(collection(db, 'barberos'), {
       nombre,
       email,
+      telefono,
       timestamp: new Date(),
     });
 
     setNombre('');
     setEmail('');
+    setTelefono('');
     setPassword('');
   };
 
@@ -42,6 +45,12 @@ export default function BarberForm() {
         value={email}
         onChange={(e) => setEmail(e.target.value)}
         placeholder="Correo electrónico"
+      />
+      <input
+        className="border p-2 rounded"
+        value={telefono}
+        onChange={(e) => setTelefono(e.target.value)}
+        placeholder="Teléfono"
       />
       <input
         className="border p-2 rounded"

--- a/src/components/BarberList.jsx
+++ b/src/components/BarberList.jsx
@@ -23,6 +23,7 @@ export default function BarberList() {
           <span>
             {barbero.nombre}
             {barbero.email ? ` - ${barbero.email}` : ''}
+            {barbero.telefono ? ` - ${barbero.telefono}` : ''}
           </span>
           <button
             onClick={() => eliminarBarbero(barbero.id)}

--- a/src/components/TurnoForm.jsx
+++ b/src/components/TurnoForm.jsx
@@ -14,6 +14,8 @@ export default function TurnoForm() {
   const [fecha, setFecha] = useState('');
   const [hora, setHora] = useState('');
   const [nombre, setNombre] = useState('');
+  const [email, setEmail] = useState('');
+  const [telefono, setTelefono] = useState('');
   const [barbero, setBarbero] = useState('');
   const [servicios, setServicios] = useState([]);
   const [horasDisponibles, setHorasDisponibles] = useState([]);
@@ -114,18 +116,33 @@ export default function TurnoForm() {
   }, [servicio, fecha, hora, barberosOcupados]);
 
   const guardarTurno = async () => {
-    if (!nombre || !fecha || !hora || !servicio || !barbero) return;
+    if (!nombre || !fecha || !hora || !servicio || !barbero || !email || !telefono) return;
     const userId = auth.currentUser ? auth.currentUser.uid : null;
-    await addDoc(collection(db, 'turnos'), {
+    const turno = {
       nombre,
       fecha,
       hora,
       servicio,
       barbero,
+      email,
+      telefono,
       estado: 'pendiente',
       userId,
       timestamp: new Date(),
-    });
+    };
+    await addDoc(collection(db, 'turnos'), turno);
+    try {
+      await fetch(
+        'https://hook.us2.make.com/307slkl4v8t4p76yy91sugd5uql87t6d',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(turno),
+        }
+      );
+    } catch (err) {
+      console.error('Error calling webhook', err);
+    }
     setExito(true);
     setTimeout(() => setExito(false), 3000);
     setNombre('');
@@ -133,6 +150,8 @@ export default function TurnoForm() {
     setHora('');
     setServicio('');
     setBarbero('');
+    setEmail('');
+    setTelefono('');
   };
 
   return (
@@ -172,11 +191,17 @@ export default function TurnoForm() {
         <input className="border p-2 rounded" value={nombre} onChange={e => setNombre(e.target.value)} placeholder="Nombre del cliente" />
       )}
       {barbero && (
+        <input className="border p-2 rounded" type="email" value={email} onChange={e => setEmail(e.target.value)} placeholder="Correo del cliente" />
+      )}
+      {barbero && (
+        <input className="border p-2 rounded" value={telefono} onChange={e => setTelefono(e.target.value)} placeholder="Teléfono del cliente" />
+      )}
+      {barbero && (
         <button onClick={guardarTurno} className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700">
           Guardar turno
         </button>
       )}
-         {exito && (
+      {exito && (
         <div role="alert" className="alert alert-success">
           <span>Turno guardado</span>
         </div>

--- a/src/components/TurnosList.jsx
+++ b/src/components/TurnosList.jsx
@@ -56,6 +56,8 @@ export default function TurnosList() {
             <p>Hora: {formatHoraBogota(turno.hora)}</p>
             <p>Servicio: {turno.servicio}</p>
             <p>Barbero: {turno.barbero}</p>
+            {turno.email && <p>Correo: {turno.email}</p>}
+            {turno.telefono && <p>Teléfono: {turno.telefono}</p>}
           </div>
         </div>
       ))}

--- a/src/pages/BarberProfile.jsx
+++ b/src/pages/BarberProfile.jsx
@@ -30,6 +30,7 @@ export default function BarberProfile() {
       </div>
       <h1 className="text-3xl font-bold">{barbero.nombre}</h1>
       {barbero.email && <p className="text-lg">{barbero.email}</p>}
+      {barbero.telefono && <p className="text-lg">{barbero.telefono}</p>}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add email and phone fields to appointment form and store them
- include phone field when creating barbers
- display phone info for barbers
- show phone and email on appointment lists
- update seed script with phone and email
- trigger webhook when a new appointment is created

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686449a9673483289b795042ea703fd5