### PR TITLE
Improve public services page design with booking

### DIFF
--- a/scripts/seedFirestore.js
+++ b/scripts/seedFirestore.js
@@ -15,8 +15,8 @@ const barbers = [
 ];
 
 const services = [
-  { nombre: 'Corte de pelo', precio: 10 },
-  { nombre: 'Afeitado', precio: 5 },
+  { nombre: 'Corte de pelo', precio: 10, descripcion: 'Corte profesional adaptado a tu estilo' },
+  { nombre: 'Afeitado', precio: 5, descripcion: 'Afeitado clásico y cuidado de la barba' },
 ];
 
 const slots = [

--- a/src/components/ServiceForm.jsx
+++ b/src/components/ServiceForm.jsx
@@ -5,16 +5,19 @@ import { collection, addDoc } from 'firebase/firestore';
 export default function ServiceForm() {
   const [nombre, setNombre] = useState('');
   const [precio, setPrecio] = useState('');
+  const [descripcion, setDescripcion] = useState('');
 
   const guardarServicio = async () => {
     if (!nombre || !precio) return;
     await addDoc(collection(db, 'servicios'), {
       nombre,
       precio: parseFloat(precio),
+      descripcion,
       timestamp: new Date(),
     });
     setNombre('');
     setPrecio('');
+    setDescripcion('');
   };
 
   return (
@@ -31,6 +34,12 @@ export default function ServiceForm() {
         value={precio}
         onChange={(e) => setPrecio(e.target.value)}
         placeholder="Precio"
+      />
+      <textarea
+        className="border p-2 rounded"
+        value={descripcion}
+        onChange={(e) => setDescripcion(e.target.value)}
+        placeholder="Descripción"
       />
       <button
         onClick={guardarServicio}

--- a/src/components/ServiceList.jsx
+++ b/src/components/ServiceList.jsx
@@ -13,6 +13,7 @@ export default function ServiceList() {
   const [editId, setEditId] = useState(null);
   const [editNombre, setEditNombre] = useState('');
   const [editPrecio, setEditPrecio] = useState('');
+  const [editDescripcion, setEditDescripcion] = useState('');
 
   useEffect(() => {
     const unsubscribe = onSnapshot(collection(db, 'servicios'), (snapshot) => {
@@ -25,12 +26,14 @@ export default function ServiceList() {
     setEditId(servicio.id);
     setEditNombre(servicio.nombre);
     setEditPrecio(servicio.precio || '');
+    setEditDescripcion(servicio.descripcion || '');
   };
 
   const cancelarEdicion = () => {
     setEditId(null);
     setEditNombre('');
     setEditPrecio('');
+    setEditDescripcion('');
   };
 
   const guardarEdicion = async () => {
@@ -38,6 +41,7 @@ export default function ServiceList() {
     await updateDoc(doc(db, 'servicios', editId), {
       nombre: editNombre,
       precio: parseFloat(editPrecio),
+      descripcion: editDescripcion,
     });
     cancelarEdicion();
   };
@@ -63,6 +67,11 @@ export default function ServiceList() {
                 value={editPrecio}
                 onChange={(e) => setEditPrecio(e.target.value)}
               />
+              <textarea
+                className="border p-1 rounded w-full"
+                value={editDescripcion}
+                onChange={(e) => setEditDescripcion(e.target.value)}
+              />
               <div className="flex justify-end space-x-2">
                 <button onClick={guardarEdicion} className="btn btn-sm btn-primary">
                   Guardar
@@ -76,25 +85,30 @@ export default function ServiceList() {
               </div>
             </div>
           ) : (
-            <div className="flex justify-between items-center">
-              <span>
-                {servicio.nombre}
-                {servicio.precio ? ` - $${servicio.precio}` : ''}
-              </span>
-              <div className="space-x-2">
-                <button
-                  onClick={() => comenzarEdicion(servicio)}
-                  className="text-blue-600 hover:underline"
-                >
-                  Editar
-                </button>
-                <button
-                  onClick={() => eliminarServicio(servicio.id)}
-                  className="text-red-600 hover:underline"
-                >
-                  Eliminar
-                </button>
+            <div>
+              <div className="flex justify-between items-center">
+                <span>
+                  {servicio.nombre}
+                  {servicio.precio ? ` - $${servicio.precio}` : ''}
+                </span>
+                <div className="space-x-2">
+                  <button
+                    onClick={() => comenzarEdicion(servicio)}
+                    className="text-blue-600 hover:underline"
+                  >
+                    Editar
+                  </button>
+                  <button
+                    onClick={() => eliminarServicio(servicio.id)}
+                    className="text-red-600 hover:underline"
+                  >
+                    Eliminar
+                  </button>
+                </div>
               </div>
+              {servicio.descripcion && (
+                <p className="text-sm opacity-80 mt-1">{servicio.descripcion}</p>
+              )}
             </div>
           )}
         </div>

--- a/src/components/TurnoForm.jsx
+++ b/src/components/TurnoForm.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { auth, db } from '../auth/FirebaseConfig';
 import {
   collection,
@@ -10,7 +11,9 @@ import {
 import { formatHoraBogota } from '../utils/time';
 
 export default function TurnoForm() {
-  const [servicio, setServicio] = useState('');
+  const [searchParams] = useSearchParams();
+  const servicioQuery = searchParams.get('servicio') || '';
+  const [servicio, setServicio] = useState(servicioQuery);
   const [fecha, setFecha] = useState('');
   const [hora, setHora] = useState('');
   const [nombre, setNombre] = useState('');
@@ -24,6 +27,10 @@ export default function TurnoForm() {
   const [turnosPorHora, setTurnosPorHora] = useState({});
   const [barberosOcupados, setBarberosOcupados] = useState([]);
   const [exito, setExito] = useState(false);
+
+  useEffect(() => {
+    if (servicioQuery) setServicio(servicioQuery);
+  }, [servicioQuery]);
 
   useEffect(() => {
     const unsubServicios = onSnapshot(collection(db, 'servicios'), snap => {

--- a/src/pages/PublicServices.jsx
+++ b/src/pages/PublicServices.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { collection, onSnapshot } from 'firebase/firestore';
+import { Link } from 'react-router-dom';
 import { db } from '../auth/FirebaseConfig';
 
 export default function PublicServices() {
@@ -13,20 +14,35 @@ export default function PublicServices() {
   }, []);
 
   return (
-    <div className="p-6 max-w-4xl mx-auto space-y-6">
+    <div className="p-6 max-w-5xl mx-auto space-y-6">
       <h1 className="text-3xl font-bold text-center">Servicios</h1>
-      <div className="grid md:grid-cols-2 gap-4">
+      <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
         {servicios.map(s => (
           <div
             key={s.id}
-            className="card bg-base-200 rounded-lg shadow transition-transform duration-300 hover:scale-105 hover:shadow-lg"
+            className="card bg-base-200 shadow hover:shadow-lg transition"
           >
-            <div className="card-body flex-row items-center justify-between">
-              <div>
-                <h2 className="card-title">{s.nombre}</h2>
-                {s.precio && <p className="text-lg">${s.precio}</p>}
+            <figure className="px-4 pt-4">
+              <img
+                className="w-24 h-24 object-contain"
+                src="https://cdn-icons-png.flaticon.com/512/7338/7338646.png"
+                alt="Icono servicio"
+              />
+            </figure>
+            <div className="card-body items-center text-center space-y-2">
+              <h2 className="card-title">{s.nombre}</h2>
+              {s.precio && <p className="opacity-70">${s.precio}</p>}
+              {s.descripcion && (
+                <p className="text-sm opacity-80">{s.descripcion}</p>
+              )}
+              <div className="card-actions mt-2">
+                <Link
+                  to={`/agendar?servicio=${encodeURIComponent(s.nombre)}`}
+                  className="btn btn-primary btn-sm"
+                >
+                  Reservar
+                </Link>
               </div>
-              <img className='w-32 h-32' src="https://cdn-icons-png.flaticon.com/512/7338/7338646.png"></img>
             </div>
           </div>
         ))}


### PR DESCRIPTION
## Summary
- redesign services listing with daisyUI cards
- allow users to reserve a service directly from `/servicios`
- support service description on admin forms and listings
- preselect service on booking page from query string
- include description field in Firestore seeding script

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eb529f080832893d489eb40aabc33