### PR TITLE
Add service image URL

### DIFF
--- a/src/components/ServiceForm.jsx
+++ b/src/components/ServiceForm.jsx
@@ -6,6 +6,7 @@ export default function ServiceForm() {
   const [nombre, setNombre] = useState('');
   const [precio, setPrecio] = useState('');
   const [descripcion, setDescripcion] = useState('');
+  const [imagen, setImagen] = useState('');
 
   const guardarServicio = async () => {
     if (!nombre || !precio) return;
@@ -13,11 +14,13 @@ export default function ServiceForm() {
       nombre,
       precio: parseFloat(precio),
       descripcion,
+      imagen,
       timestamp: new Date(),
     });
     setNombre('');
     setPrecio('');
     setDescripcion('');
+    setImagen('');
   };
 
   return (
@@ -40,6 +43,12 @@ export default function ServiceForm() {
         value={descripcion}
         onChange={(e) => setDescripcion(e.target.value)}
         placeholder="Descripción"
+      />
+      <input
+        className="border p-2 rounded"
+        value={imagen}
+        onChange={(e) => setImagen(e.target.value)}
+        placeholder="URL de la imagen"
       />
       <button
         onClick={guardarServicio}

--- a/src/components/ServiceList.jsx
+++ b/src/components/ServiceList.jsx
@@ -14,6 +14,7 @@ export default function ServiceList() {
   const [editNombre, setEditNombre] = useState('');
   const [editPrecio, setEditPrecio] = useState('');
   const [editDescripcion, setEditDescripcion] = useState('');
+  const [editImagen, setEditImagen] = useState('');
 
   useEffect(() => {
     const unsubscribe = onSnapshot(collection(db, 'servicios'), (snapshot) => {
@@ -27,6 +28,7 @@ export default function ServiceList() {
     setEditNombre(servicio.nombre);
     setEditPrecio(servicio.precio || '');
     setEditDescripcion(servicio.descripcion || '');
+    setEditImagen(servicio.imagen || '');
   };
 
   const cancelarEdicion = () => {
@@ -34,6 +36,7 @@ export default function ServiceList() {
     setEditNombre('');
     setEditPrecio('');
     setEditDescripcion('');
+    setEditImagen('');
   };
 
   const guardarEdicion = async () => {
@@ -42,6 +45,7 @@ export default function ServiceList() {
       nombre: editNombre,
       precio: parseFloat(editPrecio),
       descripcion: editDescripcion,
+      imagen: editImagen,
     });
     cancelarEdicion();
   };
@@ -67,11 +71,17 @@ export default function ServiceList() {
                 value={editPrecio}
                 onChange={(e) => setEditPrecio(e.target.value)}
               />
-              <textarea
-                className="border p-1 rounded w-full"
-                value={editDescripcion}
-                onChange={(e) => setEditDescripcion(e.target.value)}
-              />
+            <textarea
+              className="border p-1 rounded w-full"
+              value={editDescripcion}
+              onChange={(e) => setEditDescripcion(e.target.value)}
+            />
+            <input
+              className="border p-1 rounded w-full"
+              value={editImagen}
+              onChange={(e) => setEditImagen(e.target.value)}
+              placeholder="URL de la imagen"
+            />
               <div className="flex justify-end space-x-2">
                 <button onClick={guardarEdicion} className="btn btn-sm btn-primary">
                   Guardar
@@ -106,6 +116,13 @@ export default function ServiceList() {
                   </button>
                 </div>
               </div>
+              {servicio.imagen && (
+                <img
+                  src={servicio.imagen}
+                  alt={servicio.nombre}
+                  className="w-20 h-20 object-contain mt-2"
+                />
+              )}
               {servicio.descripcion && (
                 <p className="text-sm opacity-80 mt-1">{servicio.descripcion}</p>
               )}

--- a/src/pages/Landing.jsx
+++ b/src/pages/Landing.jsx
@@ -74,7 +74,11 @@ export default function Landing() {
                   <h3 className="card-title">{s.nombre}</h3>
                   {s.precio && <p className="text-lg">${s.precio}</p>}
                 </div>
-                <img className='w-32 h-32' src="https://cdn-icons-png.flaticon.com/512/7338/7338646.png"></img>
+                <img
+                  className='w-32 h-32'
+                  src={s.imagen || 'https://cdn-icons-png.flaticon.com/512/7338/7338646.png'}
+                  alt={s.nombre}
+                />
               </div>
             </div>
           ))}

--- a/src/pages/PublicServices.jsx
+++ b/src/pages/PublicServices.jsx
@@ -25,8 +25,8 @@ export default function PublicServices() {
             <figure className="px-4 pt-4">
               <img
                 className="w-24 h-24 object-contain"
-                src="https://cdn-icons-png.flaticon.com/512/7338/7338646.png"
-                alt="Icono servicio"
+                src={s.imagen || 'https://cdn-icons-png.flaticon.com/512/7338/7338646.png'}
+                alt={s.nombre}
               />
             </figure>
             <div className="card-body items-center text-center space-y-2">


### PR DESCRIPTION
## Summary
- add image URL field to service form
- support editing service images
- show service images on public pages

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686eb89d15d483289005a2a5b9a1941b