### PR TITLE
Add sidebar navigation with icons

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+
+export default function Sidebar({ sections = [], current = '', onSelect }) {
+  const [open, setOpen] = useState(
+    sections.map(() => true)
+  );
+
+  const toggle = idx => {
+    setOpen(o => o.map((v, i) => (i === idx ? !v : v)));
+  };
+
+  return (
+    <aside className="w-64 bg-base-200 min-h-screen p-4 space-y-4">
+      {sections.map((section, idx) => (
+        <div key={section.label} className="border border-base-300 rounded">
+          <button
+            className="w-full px-4 py-2 flex justify-between items-center font-semibold"
+            onClick={() => toggle(idx)}
+          >
+            <span>{section.label}</span>
+            <span>{open[idx] ? '-' : '+'}</span>
+          </button>
+          {open[idx] && (
+            <ul className="menu px-2 py-2">
+              {section.items.map(item => (
+                <li key={item.id}>
+                  {item.href ? (
+                    <a href={item.href} className="flex items-center gap-2">
+                      <item.icon />
+                      {item.label}
+                    </a>
+                  ) : (
+                    <a
+                      onClick={() => onSelect(item.id)}
+                      className={`flex items-center gap-2 ${
+                        current === item.id ? 'active' : ''
+                      }`}
+                    >
+                      <item.icon />
+                      {item.label}
+                    </a>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      ))}
+    </aside>
+  );
+}

--- a/src/icons/index.jsx
+++ b/src/icons/index.jsx
@@ -1,0 +1,99 @@
+import React from 'react';
+
+export function CalendarIcon(props) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="w-5 h-5"
+      {...props}
+    >
+      <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+      <line x1="16" y1="2" x2="16" y2="6" />
+      <line x1="8" y1="2" x2="8" y2="6" />
+      <line x1="3" y1="10" x2="21" y2="10" />
+    </svg>
+  );
+}
+
+export function ListIcon(props) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="w-5 h-5"
+      {...props}
+    >
+      <line x1="8" y1="6" x2="21" y2="6" />
+      <line x1="8" y1="12" x2="21" y2="12" />
+      <line x1="8" y1="18" x2="21" y2="18" />
+      <line x1="3" y1="6" x2="3" y2="6" />
+      <line x1="3" y1="12" x2="3" y2="12" />
+      <line x1="3" y1="18" x2="3" y2="18" />
+    </svg>
+  );
+}
+
+export function UsersIcon(props) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="w-5 h-5"
+      {...props}
+    >
+      <path d="M17 21v-2a4 4 0 0 0-3-3.87" />
+      <path d="M9 21v-2a4 4 0 0 1 3-3.87" />
+      <path d="M16 3.13a4 4 0 1 1-2.82 2.82" />
+      <path d="M6 3.13a4 4 0 1 0 2.82 2.82" />
+    </svg>
+  );
+}
+
+export function ClockIcon(props) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="w-5 h-5"
+      {...props}
+    >
+      <circle cx="12" cy="12" r="10" />
+      <polyline points="12 6 12 12 16 14" />
+    </svg>
+  );
+}
+
+export function ClipboardIcon(props) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="w-5 h-5"
+      {...props}
+    >
+      <path d="M16 4H9a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h7a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2z" />
+      <rect x="9" y="2" width="6" height="4" rx="1" ry="1" />
+    </svg>
+  );
+}

--- a/src/pages/AdminDashboard.jsx
+++ b/src/pages/AdminDashboard.jsx
@@ -4,76 +4,90 @@ import AllTurnosList from '../components/AllTurnosList';
 import BarberTurnos from '../components/BarberTurnos';
 import AllBarberSchedules from '../components/AllBarberSchedules';
 import UserMenu from '../components/UserMenu';
+import Sidebar from '../components/Sidebar';
+import {
+  CalendarIcon,
+  ListIcon,
+  UsersIcon,
+  ClockIcon,
+  ClipboardIcon,
+} from '../icons';
 
 export default function AdminDashboard() {
   const [section, setSection] = useState('nuevo');
 
+  const sections = [
+    {
+      label: 'Turnos',
+      items: [
+        { id: 'nuevo', label: 'Nuevo turno', icon: CalendarIcon },
+        { id: 'recientes', label: 'Turnos recientes', icon: ListIcon },
+        { id: 'porBarbero', label: 'Turnos por barbero', icon: UsersIcon },
+        { id: 'horarios', label: 'Horarios cargados', icon: ClockIcon },
+      ],
+    },
+    {
+      label: 'Gestionar',
+      items: [
+        { id: 'servicios', label: 'Servicios', href: '#/admin/servicios', icon: ClipboardIcon },
+        { id: 'barberos', label: 'Barberos', href: '#/admin/barberos', icon: UsersIcon },
+      ],
+    },
+  ];
+
+  const handleSelect = id => {
+    if (id === 'servicios' || id === 'barberos') {
+      window.location.hash = `/admin/${id}`;
+    } else {
+      setSection(id);
+    }
+  };
+
   return (
-    <div className="p-4 space-y-6">
-      <div className="flex justify-between items-center">
-        <h2 className="text-2xl font-bold">Panel de Administración</h2>
-        <UserMenu />
+    <div className="flex">
+      <Sidebar sections={sections} current={section} onSelect={handleSelect} />
+      <div className="p-4 space-y-6 flex-1">
+        <div className="flex justify-between items-center">
+          <h2 className="text-2xl font-bold">Panel de Administración</h2>
+          <UserMenu />
+        </div>
+
+        {section === 'nuevo' && (
+          <div className="card bg-base-100 shadow border border-base-300 w-full max-w-md mx-auto">
+            <div className="card-body">
+              <h3 className="card-title">Nuevo turno</h3>
+              <TurnoForm />
+            </div>
+          </div>
+        )}
+
+        {section === 'recientes' && (
+          <div className="card bg-base-100 shadow border border-base-300">
+            <div className="card-body">
+              <h3 className="card-title">Turnos recientes</h3>
+              <AllTurnosList />
+            </div>
+          </div>
+        )}
+
+        {section === 'porBarbero' && (
+          <div className="card bg-base-100 shadow border border-base-300">
+            <div className="card-body">
+              <h3 className="card-title">Turnos por barbero</h3>
+              <BarberTurnos />
+            </div>
+          </div>
+        )}
+
+        {section === 'horarios' && (
+          <div className="card bg-base-100 shadow border border-base-300">
+            <div className="card-body">
+              <h3 className="card-title">Horarios cargados</h3>
+              <AllBarberSchedules />
+            </div>
+          </div>
+        )}
       </div>
-
-      <div className="space-x-2">
-        <a href="#/admin/servicios" className="btn btn-sm btn-outline">Servicios</a>
-        <a href="#/admin/barberos" className="btn btn-sm btn-outline">Barberos</a>
-      </div>
-
-      <div className="divider"></div>
-
-      <ul className="menu menu-horizontal bg-base-200 rounded-box border border-base-300 shadow">
-        <li>
-          <a onClick={() => setSection('nuevo')} className={section === 'nuevo' ? 'active' : ''}>Nuevo turno</a>
-        </li>
-        <li>
-          <a onClick={() => setSection('recientes')} className={section === 'recientes' ? 'active' : ''}>Turnos recientes</a>
-        </li>
-        <li>
-          <a onClick={() => setSection('porBarbero')} className={section === 'porBarbero' ? 'active' : ''}>Turnos por barbero</a>
-        </li>
-        <li>
-          <a onClick={() => setSection('horarios')} className={section === 'horarios' ? 'active' : ''}>Horarios cargados</a>
-        </li>
-      </ul>
-
-      <div className="divider"></div>
-
-      {section === 'nuevo' && (
-        <div className="card bg-base-100 shadow border border-base-300 w-full max-w-md mx-auto">
-          <div className="card-body">
-            <h3 className="card-title">Nuevo turno</h3>
-            <TurnoForm />
-          </div>
-        </div>
-      )}
-
-      {section === 'recientes' && (
-        <div className="card bg-base-100 shadow border border-base-300">
-          <div className="card-body">
-            <h3 className="card-title">Turnos recientes</h3>
-            <AllTurnosList />
-          </div>
-        </div>
-      )}
-
-      {section === 'porBarbero' && (
-        <div className="card bg-base-100 shadow border border-base-300">
-          <div className="card-body">
-            <h3 className="card-title">Turnos por barbero</h3>
-            <BarberTurnos />
-          </div>
-        </div>
-      )}
-
-      {section === 'horarios' && (
-        <div className="card bg-base-100 shadow border border-base-300">
-          <div className="card-body">
-            <h3 className="card-title">Horarios cargados</h3>
-            <AllBarberSchedules />
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/src/pages/BarberDashboard.jsx
+++ b/src/pages/BarberDashboard.jsx
@@ -3,47 +3,39 @@ import BarberMisTurnos from '../components/BarberMisTurnos';
 import BarberScheduleForm from '../components/BarberScheduleForm';
 import BarberScheduleList from '../components/BarberScheduleList';
 import UserMenu from '../components/UserMenu';
+import Sidebar from '../components/Sidebar';
+import { CalendarIcon, ClockIcon, ListIcon } from '../icons';
 
 export default function BarberDashboard() {
   const [section, setSection] = useState('cargar');
 
+  const sections = [
+    {
+      label: 'Horarios',
+      items: [
+        { id: 'cargar', label: 'Cargar horario', icon: CalendarIcon },
+        { id: 'cargados', label: 'Horarios cargados', icon: ClockIcon },
+      ],
+    },
+    {
+      label: 'Turnos',
+      items: [
+        { id: 'turnos', label: 'Turnos asignados', icon: ListIcon },
+      ],
+    },
+  ];
+
+  const handleSelect = id => setSection(id);
+
   return (
-    <div className="p-4 space-y-6">
-      <div className="flex justify-between items-center">
-        <h2 className="text-2xl font-bold">Panel del Barbero</h2>
-        <UserMenu />
-      </div>
+    <div className="flex">
+      <Sidebar sections={sections} current={section} onSelect={handleSelect} />
+      <div className="p-4 space-y-6 flex-1">
+        <div className="flex justify-between items-center">
+          <h2 className="text-2xl font-bold">Panel del Barbero</h2>
+          <UserMenu />
+        </div>
 
-      <div className="divider"></div>
-
-      <ul className="menu menu-horizontal bg-base-200 rounded-box border border-base-300 shadow">
-        <li>
-          <a
-            onClick={() => setSection('cargar')}
-            className={section === 'cargar' ? 'active' : ''}
-          >
-            Cargar horario
-          </a>
-        </li>
-        <li>
-          <a
-            onClick={() => setSection('cargados')}
-            className={section === 'cargados' ? 'active' : ''}
-          >
-            Horarios cargados
-          </a>
-        </li>
-        <li>
-          <a
-            onClick={() => setSection('turnos')}
-            className={section === 'turnos' ? 'active' : ''}
-          >
-            Turnos asignados
-          </a>
-        </li>
-      </ul>
-
-      <div className="divider"></div>
 
       {section === 'cargar' && (
         <div className="card bg-base-100 shadow border border-base-300 w-full max-w-md mx-auto">
@@ -71,6 +63,7 @@ export default function BarberDashboard() {
           </div>
         </div>
       )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- create generic `Sidebar` component for collapsible navigation
- add simple heroicons-inspired icons
- integrate sidebar into Admin and Barber dashboards

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ebf43c92883289ebf779851e8fe23