### PR TITLE
Unify admin pages layout

### DIFF
--- a/src/constants/adminSections.js
+++ b/src/constants/adminSections.js
@@ -1,0 +1,26 @@
+import {
+  CalendarIcon,
+  ListIcon,
+  UsersIcon,
+  ClockIcon,
+  ClipboardIcon,
+} from '../icons';
+
+export const adminSections = [
+  {
+    label: 'Turnos',
+    items: [
+      { id: 'nuevo', label: 'Nuevo turno', icon: CalendarIcon },
+      { id: 'recientes', label: 'Turnos recientes', icon: ListIcon },
+      { id: 'porBarbero', label: 'Turnos por barbero', icon: UsersIcon },
+      { id: 'horarios', label: 'Horarios cargados', icon: ClockIcon },
+    ],
+  },
+  {
+    label: 'Gestionar',
+    items: [
+      { id: 'servicios', label: 'Servicios', href: '#/admin/servicios', icon: ClipboardIcon },
+      { id: 'barberos', label: 'Barberos', href: '#/admin/barberos', icon: UsersIcon },
+    ],
+  },
+];

--- a/src/layouts/AdminLayout.jsx
+++ b/src/layouts/AdminLayout.jsx
@@ -1,0 +1,17 @@
+import Sidebar from '../components/Sidebar';
+import UserMenu from '../components/UserMenu';
+
+export default function AdminLayout({ sections, current, onSelect, children }) {
+  return (
+    <div className="flex">
+      <Sidebar sections={sections} current={current} onSelect={onSelect} />
+      <div className="p-4 space-y-6 flex-1">
+        <div className="flex justify-between items-center">
+          <h2 className="text-2xl font-bold">Panel de Administración</h2>
+          <UserMenu />
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/AdminDashboard.jsx
+++ b/src/pages/AdminDashboard.jsx
@@ -32,7 +32,7 @@ export default function AdminDashboard() {
         )}
 
         {section === 'recientes' && (
-          <div className="card bg-base-100 shadow border border-base-300">
+          <div className="card bg-base-100 shadow border border-base-300 w-full max-w-4xl mx-auto">
             <div className="card-body">
               <h3 className="card-title">Turnos recientes</h3>
               <AllTurnosList />
@@ -41,7 +41,7 @@ export default function AdminDashboard() {
         )}
 
         {section === 'porBarbero' && (
-          <div className="card bg-base-100 shadow border border-base-300">
+          <div className="card bg-base-100 shadow border border-base-300 w-full max-w-4xl mx-auto">
             <div className="card-body">
               <h3 className="card-title">Turnos por barbero</h3>
               <BarberTurnos />

--- a/src/pages/AdminDashboard.jsx
+++ b/src/pages/AdminDashboard.jsx
@@ -3,37 +3,13 @@ import TurnoForm from '../components/TurnoForm';
 import AllTurnosList from '../components/AllTurnosList';
 import BarberTurnos from '../components/BarberTurnos';
 import AdminScheduleCalendar from '../components/AdminScheduleCalendar';
-import UserMenu from '../components/UserMenu';
-import Sidebar from '../components/Sidebar';
-import {
-  CalendarIcon,
-  ListIcon,
-  UsersIcon,
-  ClockIcon,
-  ClipboardIcon,
-} from '../icons';
+import AdminLayout from '../layouts/AdminLayout';
+import { adminSections } from '../constants/adminSections';
 
 export default function AdminDashboard() {
   const [section, setSection] = useState('nuevo');
 
-  const sections = [
-    {
-      label: 'Turnos',
-      items: [
-        { id: 'nuevo', label: 'Nuevo turno', icon: CalendarIcon },
-        { id: 'recientes', label: 'Turnos recientes', icon: ListIcon },
-        { id: 'porBarbero', label: 'Turnos por barbero', icon: UsersIcon },
-        { id: 'horarios', label: 'Horarios cargados', icon: ClockIcon },
-      ],
-    },
-    {
-      label: 'Gestionar',
-      items: [
-        { id: 'servicios', label: 'Servicios', href: '#/admin/servicios', icon: ClipboardIcon },
-        { id: 'barberos', label: 'Barberos', href: '#/admin/barberos', icon: UsersIcon },
-      ],
-    },
-  ];
+  const sections = adminSections;
 
   const handleSelect = id => {
     if (id === 'servicios' || id === 'barberos') {
@@ -44,13 +20,7 @@ export default function AdminDashboard() {
   };
 
   return (
-    <div className="flex">
-      <Sidebar sections={sections} current={section} onSelect={handleSelect} />
-      <div className="p-4 space-y-6 flex-1">
-        <div className="flex justify-between items-center">
-          <h2 className="text-2xl font-bold">Panel de Administración</h2>
-          <UserMenu />
-        </div>
+    <AdminLayout sections={sections} current={section} onSelect={handleSelect}>
 
         {section === 'nuevo' && (
           <div className="card bg-base-100 shadow border border-base-300 w-full max-w-md mx-auto">
@@ -87,7 +57,6 @@ export default function AdminDashboard() {
             </div>
           </div>
         )}
-      </div>
-    </div>
+    </AdminLayout>
   );
 }

--- a/src/pages/Barbers.jsx
+++ b/src/pages/Barbers.jsx
@@ -1,9 +1,19 @@
 import BarberForm from '../components/BarberForm';
 import BarberList from '../components/BarberList';
+import AdminLayout from '../layouts/AdminLayout';
+import { adminSections } from '../constants/adminSections';
 
 export default function Barbers() {
+  const sections = adminSections;
+  const handleSelect = id => {
+    if (id === 'servicios' || id === 'barberos') {
+      window.location.hash = `/admin/${id}`;
+    } else {
+      window.location.hash = '/admin';
+    }
+  };
   return (
-    <div className="p-4 space-y-6">
+    <AdminLayout sections={sections} current="barberos" onSelect={handleSelect}>
       <h2 className="text-xl font-semibold">Gestionar Barberos</h2>
 
       <div className="card bg-base-100 shadow border border-base-300 w-full max-w-md mx-auto">
@@ -19,6 +29,6 @@ export default function Barbers() {
           <BarberList />
         </div>
       </div>
-    </div>
+    </AdminLayout>
   );
 }

--- a/src/pages/Services.jsx
+++ b/src/pages/Services.jsx
@@ -1,9 +1,19 @@
 import ServiceForm from '../components/ServiceForm';
 import ServiceList from '../components/ServiceList';
+import AdminLayout from '../layouts/AdminLayout';
+import { adminSections } from '../constants/adminSections';
 
 export default function Services() {
+  const sections = adminSections;
+  const handleSelect = id => {
+    if (id === 'servicios' || id === 'barberos') {
+      window.location.hash = `/admin/${id}`;
+    } else {
+      window.location.hash = '/admin';
+    }
+  };
   return (
-    <div className="p-4 space-y-6">
+    <AdminLayout sections={sections} current="servicios" onSelect={handleSelect}>
       <h2 className="text-xl font-semibold">Gestionar Servicios</h2>
 
       <div className="card bg-base-100 shadow border border-base-300 w-full max-w-md mx-auto">
@@ -19,6 +29,6 @@ export default function Services() {
           <ServiceList />
         </div>
       </div>
-    </div>
+    </AdminLayout>
   );
 }


### PR DESCRIPTION
## Summary
- add shared admin menu configuration
- create `AdminLayout` component for shared layout
- use `AdminLayout` in `AdminDashboard`, `Services`, and `Barbers`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688c1671274083288b43478fe30e51c9