### PR TITLE
Add QR code scanning and generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "react-router-dom": "^6.0.0",
     "framer-motion": "^10.16.4",
     "react-calendar": "^4.2.0",
-    "qrcode.react": "^1.0.0",
+    "react-qr-code": "^2.0.6",
     "react-qr-reader": "^3.0.0"
   },
   "devDependencies": {
@@ -27,4 +27,6 @@
     "daisyui": "^4.11.0",
     "tailwindcss": "^3.4.4",
     "postcss": "^8.4.38",
-    "autoprefixer": "^10.4.16"  }}
+    "autoprefixer": "^10.4.16"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.0.0",
     "framer-motion": "^10.16.4",
-    "react-calendar": "^4.2.0"
+    "react-calendar": "^4.2.0",
+    "qrcode.react": "^1.0.0",
+    "react-qr-reader": "^3.0.0"
   },
   "devDependencies": {
     "gh-pages": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "framer-motion": "^10.16.4",
     "react-calendar": "^4.2.0",
     "react-qr-code": "^2.0.6",
-    "react-qr-reader": "^3.0.0"
+    "@yudiel/react-qr-scanner": "^1.1.6"
   },
   "devDependencies": {
     "gh-pages": "^5.0.0",

--- a/src/components/BarberMisTurnos.jsx
+++ b/src/components/BarberMisTurnos.jsx
@@ -3,6 +3,7 @@ import { auth, db } from '../auth/FirebaseConfig';
 import { collection, onSnapshot, query, where, doc, updateDoc } from 'firebase/firestore';
 import { onAuthStateChanged } from 'firebase/auth';
 import { getTodayBogota, formatHoraBogota } from '../utils/time';
+import QRCode from 'react-qr-code';
 
 export default function BarberMisTurnos() {
   const [turnos, setTurnos] = useState([]);
@@ -173,6 +174,9 @@ export default function BarberMisTurnos() {
               <p>
                 {t.fecha} {formatHoraBogota(t.hora)} - {t.servicio}
               </p>
+              <div className="flex justify-center">
+                <QRCode value={t.id} size={64} />
+              </div>
               <div className="space-x-2">
                 <button
                   disabled={(t.estado || 'pendiente') !== 'pendiente'}

--- a/src/components/TurnoForm.jsx
+++ b/src/components/TurnoForm.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import QRCode from 'react-qr-code';
 import { useSearchParams } from 'react-router-dom';
 import { auth, db } from '../auth/FirebaseConfig';
@@ -30,6 +30,7 @@ export default function TurnoForm({ showSteps = false }) {
   const [barberosOcupados, setBarberosOcupados] = useState([]);
   const [exito, setExito] = useState(false);
   const [qrId, setQrId] = useState('');
+  const qrRef = useRef(null);
 
   const currentStep = !servicio
     ? 1
@@ -176,6 +177,22 @@ export default function TurnoForm({ showSteps = false }) {
     setTelefono('');
   };
 
+  const descargarQR = () => {
+    const container = qrRef.current;
+    if (!container) return;
+    const svg = container.querySelector('svg');
+    if (!svg) return;
+    const serializer = new XMLSerializer();
+    const svgString = serializer.serializeToString(svg);
+    const blob = new Blob([svgString], { type: 'image/svg+xml' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `turno-${qrId}.svg`;
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
   return (
     <div className="flex flex-col space-y-2 mb-4">
       {showSteps && (
@@ -240,8 +257,11 @@ export default function TurnoForm({ showSteps = false }) {
         </div>
       )}
       {qrId && (
-        <div className="flex justify-center pt-4">
+        <div className="flex flex-col items-center pt-4" ref={qrRef}>
           <QRCode value={qrId} />
+          <button onClick={descargarQR} className="btn btn-sm mt-2">
+            Descargar QR
+          </button>
         </div>
       )}
     </div>

--- a/src/components/TurnoForm.jsx
+++ b/src/components/TurnoForm.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { QRCodeSVG } from 'qrcode.react';
+import QRCode from 'react-qr-code';
 import { useSearchParams } from 'react-router-dom';
 import { auth, db } from '../auth/FirebaseConfig';
 import {
@@ -239,7 +239,7 @@ export default function TurnoForm({ showSteps = false }) {
       )}
       {qrId && (
         <div className="flex justify-center pt-4">
-          <QRCodeSVG value={qrId} />
+          <QRCode value={qrId} />
         </div>
       )}
     </div>

--- a/src/components/TurnoForm.jsx
+++ b/src/components/TurnoForm.jsx
@@ -5,6 +5,7 @@ import { auth, db } from '../auth/FirebaseConfig';
 import {
   collection,
   addDoc,
+  updateDoc,
   onSnapshot,
   query,
   where,
@@ -150,6 +151,7 @@ export default function TurnoForm({ showSteps = false }) {
       timestamp: new Date(),
     };
     const docRef = await addDoc(collection(db, 'turnos'), turno);
+    await updateDoc(docRef, { qrId: docRef.id });
     setQrId(docRef.id);
     try {
       await fetch(

--- a/src/components/TurnoForm.jsx
+++ b/src/components/TurnoForm.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { QRCodeSVG } from 'qrcode.react';
 import { useSearchParams } from 'react-router-dom';
 import { auth, db } from '../auth/FirebaseConfig';
 import {
@@ -27,6 +28,7 @@ export default function TurnoForm({ showSteps = false }) {
   const [turnosPorHora, setTurnosPorHora] = useState({});
   const [barberosOcupados, setBarberosOcupados] = useState([]);
   const [exito, setExito] = useState(false);
+  const [qrId, setQrId] = useState('');
 
   const currentStep = !servicio
     ? 1
@@ -147,14 +149,15 @@ export default function TurnoForm({ showSteps = false }) {
       userId,
       timestamp: new Date(),
     };
-    await addDoc(collection(db, 'turnos'), turno);
+    const docRef = await addDoc(collection(db, 'turnos'), turno);
+    setQrId(docRef.id);
     try {
       await fetch(
         'https://hook.us2.make.com/307slkl4v8t4p76yy91sugd5uql87t6d',
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(turno),
+          body: JSON.stringify({ ...turno, id: docRef.id }),
         }
       );
     } catch (err) {
@@ -232,6 +235,11 @@ export default function TurnoForm({ showSteps = false }) {
       {exito && (
         <div role="alert" className="alert alert-success">
           <span>Turno guardado</span>
+        </div>
+      )}
+      {qrId && (
+        <div className="flex justify-center pt-4">
+          <QRCodeSVG value={qrId} />
         </div>
       )}
     </div>

--- a/src/components/TurnoScanner.jsx
+++ b/src/components/TurnoScanner.jsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import { db } from '../auth/FirebaseConfig';
+import { doc, updateDoc } from 'firebase/firestore';
+import { QrReader } from 'react-qr-reader';
+
+export default function TurnoScanner() {
+  const [message, setMessage] = useState('');
+
+  const handleResult = async (result, error) => {
+    if (!!result) {
+      const scannedId = result?.text || result;
+      try {
+        await updateDoc(doc(db, 'turnos', scannedId), { estado: 'atendido' });
+        setMessage('Turno confirmado');
+      } catch (err) {
+        setMessage('Error al actualizar');
+      }
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-2xl font-bold">Escanear turno</h2>
+      <QrReader onResult={handleResult} constraints={{ facingMode: 'environment' }} />
+      {message && (
+        <div role="alert" className="alert alert-success">
+          <span>{message}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/TurnoScanner.jsx
+++ b/src/components/TurnoScanner.jsx
@@ -1,27 +1,26 @@
 import { useState } from 'react';
 import { db } from '../auth/FirebaseConfig';
 import { doc, updateDoc } from 'firebase/firestore';
-import { QrReader } from 'react-qr-reader';
+import { QrScanner } from '@yudiel/react-qr-scanner';
 
 export default function TurnoScanner() {
   const [message, setMessage] = useState('');
 
-  const handleResult = async (result, error) => {
-    if (!!result) {
-      const scannedId = result?.text || result;
-      try {
-        await updateDoc(doc(db, 'turnos', scannedId), { estado: 'atendido' });
-        setMessage('Turno confirmado');
-      } catch (err) {
-        setMessage('Error al actualizar');
-      }
+  const handleResult = async result => {
+    if (!result) return;
+    const scannedId = result?.text || result;
+    try {
+      await updateDoc(doc(db, 'turnos', scannedId), { estado: 'atendido' });
+      setMessage('Turno confirmado');
+    } catch (err) {
+      setMessage('Error al actualizar');
     }
   };
 
   return (
     <div className="space-y-4">
       <h2 className="text-2xl font-bold">Escanear turno</h2>
-      <QrReader onResult={handleResult} constraints={{ facingMode: 'environment' }} />
+      <QrScanner onDecode={handleResult} onError={() => {}} />
       {message && (
         <div role="alert" className="alert alert-success">
           <span>{message}</span>

--- a/src/pages/BarberDashboard.jsx
+++ b/src/pages/BarberDashboard.jsx
@@ -4,7 +4,7 @@ import BarberScheduleForm from '../components/BarberScheduleForm';
 import BarberScheduleCalendar from '../components/BarberScheduleCalendar';
 import UserMenu from '../components/UserMenu';
 import Sidebar from '../components/Sidebar';
-import { CalendarIcon, ClockIcon, ListIcon } from '../icons';
+import { CalendarIcon, ClockIcon, ListIcon, ClipboardIcon } from '../icons';
 
 export default function BarberDashboard() {
   const [section, setSection] = useState('cargar');
@@ -21,6 +21,7 @@ export default function BarberDashboard() {
       label: 'Turnos',
       items: [
         { id: 'turnos', label: 'Turnos asignados', icon: ListIcon },
+        { id: 'scanner', label: 'Escanear turno', href: '#/scanner', icon: ClipboardIcon },
       ],
     },
   ];

--- a/src/pages/Scanner.jsx
+++ b/src/pages/Scanner.jsx
@@ -1,0 +1,9 @@
+import TurnoScanner from '../components/TurnoScanner';
+
+export default function Scanner() {
+  return (
+    <div className="p-4">
+      <TurnoScanner />
+    </div>
+  );
+}

--- a/src/router/AppRouter.jsx
+++ b/src/router/AppRouter.jsx
@@ -9,6 +9,7 @@ import BarberProfile from '../pages/BarberProfile';
 import AdminDashboard from '../pages/AdminDashboard';
 import Agendar from '../pages/Agendar';
 import BarberDashboard from '../pages/BarberDashboard';
+import Scanner from '../pages/Scanner';
 
 export default function AppRouter() {
   return (
@@ -21,6 +22,7 @@ export default function AppRouter() {
         <Route path="/barberos/:id" element={<BarberProfile />} />
         <Route path="/agendar" element={<Agendar />} />
         <Route path="/barbero" element={<BarberDashboard />} />
+        <Route path="/scanner" element={<Scanner />} />
         <Route path="/admin" element={<AdminDashboard />} />
         <Route path="/admin/servicios" element={<Services />} />
         <Route path="/admin/barberos" element={<Barbers />} />


### PR DESCRIPTION
## Summary
- add qr dependencies in package.json
- show a QR code in `TurnoForm` after saving
- add a QR scanner component and page
- route `/scanner` to launch the scanner and link from barber dashboard

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: cannot resolve `react-qr-reader`)*

------
https://chatgpt.com/codex/tasks/task_e_688c1fca1fb48328a54b97bb196b5852